### PR TITLE
Improve event horizon contracts

### DIFF
--- a/Source/EventHorizon/Consumer.proto
+++ b/Source/EventHorizon/Consumer.proto
@@ -3,6 +3,7 @@
 
 syntax = "proto3";
 
+import "EventHorizon/SubscriptionResponse.proto";
 import "EventHorizon/EventHorizonEvent.proto";
 
 package dolittle.runtime.eventhorizon;
@@ -16,6 +17,12 @@ message ConsumerSubscription {
     int64 lastReceived = 4; // -1 = Haven't received any
 }
 
+message SubscriptionStreamMessage {
+    oneof Message {
+        SubscriptionResponse subscriptionResponse = 1;
+        EventHorizonEvent event = 2;
+    }
+}
 service Consumer {
-    rpc Subscribe(ConsumerSubscription) returns(stream EventHorizonEvent);
+    rpc Subscribe(ConsumerSubscription) returns(stream SubscriptionStreamMessage);
 }

--- a/Source/EventHorizon/Failure.proto
+++ b/Source/EventHorizon/Failure.proto
@@ -1,0 +1,12 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+syntax = "proto3";
+
+package dolittle.runtime.eventhorizon;
+
+option csharp_namespace = "Dolittle.Runtime.EventHorizon";
+
+message Failure {
+    string reason = 1;
+}

--- a/Source/EventHorizon/SubscriptionResponse.proto
+++ b/Source/EventHorizon/SubscriptionResponse.proto
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+syntax = "proto3";
+
+import "EventHorizon/Failure.proto";
+
+package dolittle.runtime.eventhorizon;
+
+option csharp_namespace = "Dolittle.Runtime.EventHorizon";
+
+message SubscriptionResponse {
+    Failure failure = 1;
+}

--- a/Source/EventHorizon/Subscriptions.proto
+++ b/Source/EventHorizon/Subscriptions.proto
@@ -3,6 +3,8 @@
 
 syntax = "proto3";
 
+import "EventHorizon/SubscriptionResponse.proto";
+
 package dolittle.runtime.eventhorizon;
 
 option csharp_namespace = "Dolittle.Runtime.EventHorizon";
@@ -13,11 +15,6 @@ message Subscription {
     bytes stream = 3;
     bytes partition = 4;
     bytes scope = 5;
-}
-
-message SubscriptionResponse {
-    bool success = 1;
-    string reason = 2;
 }
 
 service Subscriptions {


### PR DESCRIPTION
This PR:
Adds
* The Failure message to the 'eventhorizon' package which is used in a response to indicate a failure. This proto definition we should move into a fundamentals protobuf project for reuse.
* SubscriptionResponse message used in both the subscription contracts to represent the failure of a subscription request if any.

Changes
* The server response of the Consumer Subscribe service now returns a stream of SubscriptionStreamMessage which can hold one of SubscriptionResponse or an event from the event horizon. The first message in the response stream should be a SubscriptionResponse representing whether the subscription was successful. The rest of the messages should be the events.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1169773153194218)
