### PR TITLE
Introduce StreamEvent to event processors

### DIFF
--- a/Source/Runtime/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Events.Processing/EventHandlers.proto
@@ -7,7 +7,7 @@ import "Fundamentals/Artifacts/Artifact.proto";
 import "Fundamentals/Protobuf/Uuid.proto";
 import "Fundamentals/Protobuf/Failure.proto";
 import "Fundamentals/Services/ReverseCallContext.proto";
-import "Runtime/Events/Committed.proto";
+import "Runtime/Events.Processing/StreamEvent.proto";
 import "Runtime/Events.Processing/Processors.proto";
 
 package dolittle.runtime.events.processing;
@@ -40,9 +40,8 @@ message EventHandlerRegistrationResponse {
 
 message HandleEventRequest {
     services.ReverseCallRequestContext callContext = 1;
-    runtime.events.CommittedEvent event = 2;
-    protobuf.Uuid partitionId = 3;
-    RetryProcessingState retryProcessingState = 4;
+    StreamEvent event = 2;
+    RetryProcessingState retryProcessingState = 3;
 }
 
 message EventHandlerRuntimeToClientMessage {

--- a/Source/Runtime/Events.Processing/Filters.proto
+++ b/Source/Runtime/Events.Processing/Filters.proto
@@ -6,7 +6,7 @@ syntax = "proto3";
 import "Fundamentals/Protobuf/Uuid.proto";
 import "Fundamentals/Protobuf/Failure.proto";
 import "Fundamentals/Services/ReverseCallContext.proto";
-import "Runtime/Events/Committed.proto";
+import "Runtime/Events.Processing/StreamEvent.proto";
 import "Runtime/Events.Processing/Processors.proto";
 
 package dolittle.runtime.events.processing;
@@ -39,9 +39,8 @@ message FilterRegistrationResponse {
 
 message FilterEventRequest {
     services.ReverseCallRequestContext callContext = 1;
-    runtime.events.CommittedEvent event = 2;
-    protobuf.Uuid partitionId = 3;
-    RetryProcessingState retryProcessingState = 4;
+    StreamEvent event = 2;
+    RetryProcessingState retryProcessingState = 3;
 }
 
 message FilterRuntimeToClientMessage {

--- a/Source/Runtime/Events.Processing/Processors.proto
+++ b/Source/Runtime/Events.Processing/Processors.proto
@@ -6,7 +6,7 @@ syntax = "proto3";
 import "Fundamentals/Protobuf/Failure.proto";
 import "Fundamentals/Protobuf/Uuid.proto";
 import "Fundamentals/Services/ReverseCallContext.proto";
-import "Runtime/Events/Committed.proto";
+import "Runtime/Events.Processing/StreamEvent.proto";
 import "google/protobuf/duration.proto";
 
 package dolittle.runtime.events.processing;
@@ -47,9 +47,8 @@ message ProcessorRegistrationResponse {
 
 message ProcessEventRequest {
     services.ReverseCallRequestContext callContext = 1;
-    runtime.events.CommittedEvent event = 2;
-    protobuf.Uuid partitionId = 3;
-    RetryProcessingState retryProcessingState = 4;
+    StreamEvent event = 2;
+    RetryProcessingState retryProcessingState = 3;
 }
 
 message ProcessorRuntimeToClientMessage {

--- a/Source/Runtime/Events.Processing/StreamEvent.proto
+++ b/Source/Runtime/Events.Processing/StreamEvent.proto
@@ -1,0 +1,17 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+syntax = "proto3";
+
+import "Fundamentals/Protobuf/Uuid.proto";
+import "Runtime/Events/Committed.proto";
+
+package dolittle.runtime.events.processing;
+
+option csharp_namespace = "Dolittle.Runtime.Events.Processing.Contracts";
+
+message StreamEvent {
+    runtime.events.CommittedEvent event = 1;
+    protobuf.Uuid partitionId = 2;
+    protobuf.Uuid scopeId = 3;
+}


### PR DESCRIPTION
Combines the CommittedEvent, PartitionId and ScopeId into a message called 'StreamEvent' and use that in the event processors

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1172170241019066)
