### PR TITLE
Remove 'occurred' timestamp from uncommitted events

### DIFF
--- a/Source/Runtime/Events/Uncommitted.proto
+++ b/Source/Runtime/Events/Uncommitted.proto
@@ -14,17 +14,15 @@ option csharp_namespace = "Dolittle.Runtime.Events.Contracts";
 message UncommittedEvent {
     artifacts.Artifact artifact = 1;
     protobuf.Uuid eventSourceId = 2;
-    google.protobuf.Timestamp occurred = 3;
-    bool public = 4;
-    string content = 5;
+    bool public = 3;
+    string content = 4;
 }
 
 message UncommittedAggregateEvents {
     message UncommittedAggregateEvent {
         artifacts.Artifact artifact = 1;
-        google.protobuf.Timestamp occurred = 2;
-        bool public = 3;
-        string content = 4;
+        bool public = 2;
+        string content = 3;
     }
     protobuf.Uuid aggregateRootId = 1;
     protobuf.Uuid eventSourceId = 2;


### PR DESCRIPTION
Uncommitted events does not need an occurred Timestamp

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1140654762299587/1172516132134890)
