### PR TITLE
Go code generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -359,4 +359,6 @@ Generation/**/*.js
 Generation/**/*.ts
 Generation/**/*.d.ts
 
+build-go
+
 !Source/**/Artifacts

--- a/Source/Fundamentals/Artifacts/Artifact.proto
+++ b/Source/Fundamentals/Artifacts/Artifact.proto
@@ -8,6 +8,7 @@ import "Fundamentals/Protobuf/Uuid.proto";
 package dolittle.artifacts;
 
 option csharp_namespace = "Dolittle.Artifacts.Contracts";
+option go_package = "go.dolittle.io/contracts/artifacts";
 
 message Artifact {
     protobuf.Uuid id = 1;

--- a/Source/Fundamentals/Execution/ExecutionContext.proto
+++ b/Source/Fundamentals/Execution/ExecutionContext.proto
@@ -10,6 +10,7 @@ import "Fundamentals/Versioning/Version.proto";
 package dolittle.execution;
 
 option csharp_namespace = "Dolittle.Execution.Contracts";
+option go_package = "go.dolittle.io/contracts/execution";
 
 message ExecutionContext {
     protobuf.Uuid microserviceId = 1;

--- a/Source/Fundamentals/Protobuf/Failure.proto
+++ b/Source/Fundamentals/Protobuf/Failure.proto
@@ -8,6 +8,7 @@ import "Fundamentals/Protobuf/Uuid.proto";
 package dolittle.protobuf;
 
 option csharp_namespace = "Dolittle.Protobuf.Contracts";
+option go_package = "go.dolittle.io/contracts/protobuf";
 
 message Failure {
     Uuid id = 1;

--- a/Source/Fundamentals/Protobuf/Uuid.proto
+++ b/Source/Fundamentals/Protobuf/Uuid.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 package dolittle.protobuf;
 
 option csharp_namespace = "Dolittle.Protobuf.Contracts";
+option go_package = "go.dolittle.io/contracts/protobuf";
 
 message Uuid {
     bytes value = 1;

--- a/Source/Fundamentals/Security/Claim.proto
+++ b/Source/Fundamentals/Security/Claim.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 package dolittle.security;
 
 option csharp_namespace = "Dolittle.Security.Contracts";
+option go_package = "go.dolittle.io/contracts/security";
 
 message Claim {
     string key = 1;

--- a/Source/Fundamentals/Services/CallContext.proto
+++ b/Source/Fundamentals/Services/CallContext.proto
@@ -9,6 +9,7 @@ import "Fundamentals/Protobuf/Uuid.proto";
 package dolittle.services;
 
 option csharp_namespace = "Dolittle.Services.Contracts";
+option go_package = "go.dolittle.io/contracts/services";
 
 message CallRequestContext {
     execution.ExecutionContext executionContext = 1;

--- a/Source/Fundamentals/Services/Ping.proto
+++ b/Source/Fundamentals/Services/Ping.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 package dolittle.services;
 
 option csharp_namespace = "Dolittle.Services.Contracts";
+option go_package = "go.dolittle.io/contracts/services";
 
 message Ping {
 

--- a/Source/Fundamentals/Services/ReverseCallContext.proto
+++ b/Source/Fundamentals/Services/ReverseCallContext.proto
@@ -10,6 +10,7 @@ import "google/protobuf/duration.proto";
 package dolittle.services;
 
 option csharp_namespace = "Dolittle.Services.Contracts";
+option go_package = "go.dolittle.io/contracts/services";
 
 message ReverseCallArgumentsContext {
     execution.ExecutionContext executionContext = 1;

--- a/Source/Fundamentals/Versioning/Version.proto
+++ b/Source/Fundamentals/Versioning/Version.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 package dolittle.versioning;
 
 option csharp_namespace = "Dolittle.Versioning.Contracts";
+option go_package = "go.dolittle.io/contracts/versioning";
 
 message Version {
     int32 major = 1;

--- a/Source/Runtime/EventHorizon/Consumer.proto
+++ b/Source/Runtime/EventHorizon/Consumer.proto
@@ -13,6 +13,7 @@ import "Runtime/Events/Committed.proto";
 package dolittle.runtime.eventhorizon;
 
 option csharp_namespace = "Dolittle.Runtime.EventHorizon.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/eventhorizon";
 
 message EventHorizonEvent {
     uint64 streamSequenceNumber = 1;

--- a/Source/Runtime/EventHorizon/Subscriptions.proto
+++ b/Source/Runtime/EventHorizon/Subscriptions.proto
@@ -10,6 +10,7 @@ import "Fundamentals/Protobuf/Failure.proto";
 package dolittle.runtime.eventhorizon;
 
 option csharp_namespace = "Dolittle.Runtime.EventHorizon.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/eventhorizon";
 
 message SubscriptionResponse {
     protobuf.Failure failure = 1;

--- a/Source/Runtime/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Events.Processing/EventHandlers.proto
@@ -14,6 +14,7 @@ import "Runtime/Events.Processing/Processors.proto";
 package dolittle.runtime.events.processing;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Processing.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events/processing";
 
 message EventHandlerRegistrationRequest {
     services.ReverseCallArgumentsContext callContext = 1;

--- a/Source/Runtime/Events.Processing/Filters.proto
+++ b/Source/Runtime/Events.Processing/Filters.proto
@@ -15,6 +15,7 @@ import "Runtime/Events.Processing/PublicFilters.proto";
 package dolittle.runtime.events.processing;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Processing.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events/processing";
 
 message FilterRegistrationResponse {
     protobuf.Failure failure = 1;

--- a/Source/Runtime/Events.Processing/PartitionedFilters.proto
+++ b/Source/Runtime/Events.Processing/PartitionedFilters.proto
@@ -11,6 +11,7 @@ import "Runtime/Events.Processing/Processors.proto";
 package dolittle.runtime.events.processing;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Processing.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events/processing";
 
 message PartitionedFilterRegistrationRequest {
     services.ReverseCallArgumentsContext callContext = 1;

--- a/Source/Runtime/Events.Processing/Processors.proto
+++ b/Source/Runtime/Events.Processing/Processors.proto
@@ -13,6 +13,7 @@ import "google/protobuf/duration.proto";
 package dolittle.runtime.events.processing;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Processing.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events/processing";
 
 message ProcessorFailure {
     string reason = 1;

--- a/Source/Runtime/Events.Processing/PublicFilters.proto
+++ b/Source/Runtime/Events.Processing/PublicFilters.proto
@@ -11,6 +11,7 @@ import "Runtime/Events.Processing/PartitionedFilters.proto";
 package dolittle.runtime.events.processing;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Processing.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events/processing";
 
 message PublicFilterRegistrationRequest {
     services.ReverseCallArgumentsContext callContext = 1;

--- a/Source/Runtime/Events.Processing/StreamEvent.proto
+++ b/Source/Runtime/Events.Processing/StreamEvent.proto
@@ -9,6 +9,7 @@ import "Runtime/Events/Committed.proto";
 package dolittle.runtime.events.processing;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Processing.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events/processing";
 
 message StreamEvent {
     runtime.events.CommittedEvent event = 1;

--- a/Source/Runtime/Events/Aggregate.proto
+++ b/Source/Runtime/Events/Aggregate.proto
@@ -8,6 +8,7 @@ import "Fundamentals/Protobuf/Uuid.proto";
 package dolittle.runtime.events;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events";
 
 message Aggregate {
     protobuf.Uuid eventSourceId = 1;

--- a/Source/Runtime/Events/Committed.proto
+++ b/Source/Runtime/Events/Committed.proto
@@ -11,6 +11,7 @@ import "google/protobuf/timestamp.proto";
 package dolittle.runtime.events;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events";
 
 message CommittedEvent {
     uint64 eventLogSequenceNumber = 1; 

--- a/Source/Runtime/Events/EventStore.proto
+++ b/Source/Runtime/Events/EventStore.proto
@@ -12,6 +12,7 @@ import "Runtime/Events/Uncommitted.proto";
 package dolittle.runtime.events;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events";
 
 message CommitEventsRequest {
     services.CallRequestContext callContext = 1; 

--- a/Source/Runtime/Events/Uncommitted.proto
+++ b/Source/Runtime/Events/Uncommitted.proto
@@ -9,6 +9,7 @@ import "Fundamentals/Protobuf/Uuid.proto";
 package dolittle.runtime.events;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events";
 
 message UncommittedEvent {
     artifacts.Artifact artifact = 1;

--- a/buildGo.sh
+++ b/buildGo.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+rm -r ./build-go >/dev/null
+
+MAJOR_VERSION="5"
+
+PATTERN='^(option go_package = "go.dolittle.io\/contracts)(\/[^"]*";)$'
+
+echo "Adding major version $MAJOR_VERSION in package paths..."
+mkdir -p ./build-go/versioned
+find . -name '*.proto' | while read PROTOFILE; do
+    if ! egrep -q "$PATTERN" "$PROTOFILE"; then
+        echo "Error: go_package was not found in $PROTOFILE. Will stop to not publish wrong package version."
+        exit 1
+    fi
+    mkdir -p $(dirname "./build-go/versioned/$PROTOFILE")
+    sed -r "s/$PATTERN/\1\/v$MAJOR_VERSION\2/g" "./$PROTOFILE" > "./build-go/versioned/$PROTOFILE"
+    echo "Added major version for $PROTOFILE"
+done
+
+echo "Generating Go code..."
+mkdir -p ./build-go/generated
+find ./build-go/versioned -name '*.proto' | while read PROTOFILE; do
+    protoc  --proto_path=./build-go/versioned/Source \
+            --go_out=./build-go/generated --go_opt=module="go.dolittle.io/contracts/v$MAJOR_VERSION" \
+            --go-grpc_out=./build-go/generated --go-grpc_opt=module="go.dolittle.io/contracts/v$MAJOR_VERSION" \
+            "$PROTOFILE"
+    echo "Generated code Go for $PROTOFILE"
+done
+
+pushd build-go/generated
+
+echo "Initializing Go module..."
+go mod init "go.dolittle.io/contracts/v$MAJOR_VERSION"
+
+echo "Resolving Go dependencies..."
+go mod tidy
+
+echo "Ensuring generated Go code compiles builds..."
+go build -v ./...
+
+popd


### PR DESCRIPTION
Go treats packages (and modules) somewhat differently from other languages. So currently the plan is to publish all the generated Go code as a single module `go.dolittle.io/contracts` that contains both the Fundamentals and Runtime files.

There is no official Go package repository - and since it always compiles from source it is common for people to host the code on e.g. GitHub. The plan is for the generated Go code to live on a repository e.g. `github.com/dolittle/Contracts-Go`, and whenever this repository is released, to commit the generated module to that repository (overwriting any previous code) and giving it a `vX.X.X` tag to indicate a release.

Since Go deals with major version releases in a special manner, the `./buildGo.sh` script does some magic to add `vMajor` into the package path - this should come from the established build context in the build pipelines so what we don't have to manually update the .proto files to match the current release.

Although not necessary - it would be nice to have Go imports from something like `go.dolittle.io/...` in place of the actual GitHub repository (so we are more free with naming the repositories). I have on the side tested this out a little, and it seems like setting up a little HTTP server to resolve the packages to their actual repositories is quite easy (see https://golang.org/ref/mod#vcs-find). This HTTP server could also in the future serve the generated godocs to provide a nice DX.