### PR TITLE
Adding service definitions for Projections

### DIFF
--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -1,0 +1,60 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+syntax = "proto3";
+
+import "Fundamentals/Artifacts/Artifact.proto";
+import "Fundamentals/Protobuf/Uuid.proto";
+import "Fundamentals/Protobuf/Failure.proto";
+import "Fundamentals/Services/ReverseCallContext.proto";
+import "Fundamentals/Services/Ping.proto";
+import "Runtime/Events.Processing/StreamEvent.proto";
+import "Runtime/Events.Processing/Processors.proto";
+
+package dolittle.runtime.events.processing;
+
+option csharp_namespace = "Dolittle.Runtime.Events.Processing.Contracts";
+
+message ProjectionRegistrationRequest {
+    services.ReverseCallArgumentsContext callContext = 1;
+    protobuf.Uuid scopeId = 2; // TODO: Should we have this?
+    protobuf.Uuid projectionId = 3;
+    repeated artifacts.Artifact types = 4; // TODO: Change this to include key selector
+}
+
+message ProjectionResponse {
+    services.ReverseCallResponseContext callContext = 1;
+    ProcessorFailure failure = 2; // If not set/empty - no failure
+    // TODO: Add projection state response here
+}
+
+message ProjectionClientToRuntimeMessage {
+    oneof Message {
+        ProjectionRegistrationRequest registrationRequest = 1;
+        ProjectionResponse handleResult = 2;
+        services.Pong pong = 3;
+    }
+}
+
+message ProjectionRegistrationResponse {
+    protobuf.Failure failure = 1;
+}
+
+message ProjectionRequest {
+    services.ReverseCallRequestContext callContext = 1;
+    StreamEvent event = 2;
+    RetryProcessingState retryProcessingState = 3;
+    // TODO: Add projection state here
+}
+
+message ProjectionRuntimeToClientMessage {
+    oneof Message {
+        ProjectionRegistrationResponse registrationResponse = 1;
+        ProjectionRequest handleRequest = 2;
+        services.Ping ping = 3;
+    }
+}
+
+service Projections {
+    rpc Connect(stream ProjectionClientToRuntimeMessage) returns(stream ProjectionRuntimeToClientMessage);
+}

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -26,7 +26,7 @@ message ProjectionEventKeySelector {
     optional string expression = 2;
 }
 
-message ProjectionEventSpecification {
+message ProjectionEventSelector {
     artifacts.Artifact eventType = 1;
     ProjectionEventKeySelector keySelector = 2;
 }
@@ -35,7 +35,7 @@ message ProjectionRegistrationRequest {
     services.ReverseCallArgumentsContext callContext = 1;
     protobuf.Uuid scopeId = 2;
     protobuf.Uuid projectionId = 3;
-    repeated ProjectionEventSpecification events = 4;
+    repeated ProjectionEventSelector events = 4;
     string initialState = 5;
 }
 

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -46,7 +46,7 @@ enum ProjectionNextStateType {
 
 message ProjectionNextState {
     ProjectionNextStateType type = 1;
-    string value = 1;
+    string value = 2;
 }
 
 message ProjectionResponse {

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -32,11 +32,22 @@ message ProjectionRegistrationRequest {
     protobuf.Uuid scopeId = 2;
     protobuf.Uuid projectionId = 3;
     repeated ProjectionEventSpecification events = 4;
+    string initialState = 5;
+}
+
+enum ProjectionNextStateType {
+    REPLACE = 0;
+    DELETE = 1;
+}
+
+message ProjectionNextState {
+    ProjectionNextStateType type = 1;
+    string value = 1;
 }
 
 message ProjectionResponse {
     services.ReverseCallResponseContext callContext = 1;
-    string nextState = 2;
+    ProjectionNextState nextState = 2;
     ProcessorFailure failure = 3; // If not set/empty - no failure
 }
 
@@ -52,9 +63,19 @@ message ProjectionRegistrationResponse {
     protobuf.Failure failure = 1;
 }
 
+enum ProjectionCurrentStateType {
+    CREATED_FROM_INITIAL_STATE = 0;
+    PERSISTED = 1;
+}
+
+message ProjectionCurrentState {
+    ProjectionCurrentStateType type = 1;
+    string state = 2;
+}
+
 message ProjectionRequest {
     services.ReverseCallRequestContext callContext = 1;
-    string previousState = 2;
+    ProjectionCurrentState currentState = 2;
     StreamEvent event = 3;
     RetryProcessingState retryProcessingState = 4;
 }

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -29,7 +29,7 @@ message ProjectionEventSpecification {
 
 message ProjectionRegistrationRequest {
     services.ReverseCallArgumentsContext callContext = 1;
-    protobuf.Uuid scopeId = 2; // TODO: Should we have this?
+    protobuf.Uuid scopeId = 2;
     protobuf.Uuid projectionId = 3;
     repeated ProjectionEventSpecification events = 4;
 }

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -15,11 +15,23 @@ package dolittle.runtime.events.processing;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Processing.Contracts";
 
+enum ProjectEventKeySelectorType {
+    EVENT_SOURCE_ID = 0;
+    PARTITION_ID = 1;
+    PROPERTY = 2;
+}
+
+message ProjectionEventSpecification {
+    artifacts.Artifact eventType = 1;
+    ProjectEventKeySelectorType keySelectorType = 2;
+    string keySelectorExpression = 3;
+}
+
 message ProjectionRegistrationRequest {
     services.ReverseCallArgumentsContext callContext = 1;
     protobuf.Uuid scopeId = 2; // TODO: Should we have this?
     protobuf.Uuid projectionId = 3;
-    repeated artifacts.Artifact types = 4; // TODO: Change this to include key selector
+    repeated ProjectionEventSpecification events = 4;
 }
 
 message ProjectionResponse {

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -21,10 +21,14 @@ enum ProjectEventKeySelectorType {
     PROPERTY = 2;
 }
 
+message ProjectionEventKeySelector {
+    ProjectEventKeySelectorType type = 1;
+    optional string expression = 2;
+}
+
 message ProjectionEventSpecification {
     artifacts.Artifact eventType = 1;
-    ProjectEventKeySelectorType keySelectorType = 2;
-    string keySelectorExpression = 3;
+    ProjectionEventKeySelector keySelector = 2;
 }
 
 message ProjectionRegistrationRequest {

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -23,7 +23,7 @@ enum ProjectEventKeySelectorType {
 
 message ProjectionEventKeySelector {
     ProjectEventKeySelectorType type = 1;
-    optional string expression = 2;
+    string expression = 2;
 }
 
 message ProjectionEventSelector {

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -24,8 +24,8 @@ message ProjectionRegistrationRequest {
 
 message ProjectionResponse {
     services.ReverseCallResponseContext callContext = 1;
-    ProcessorFailure failure = 2; // If not set/empty - no failure
-    // TODO: Add projection state response here
+    string nextState = 2;
+    ProcessorFailure failure = 3; // If not set/empty - no failure
 }
 
 message ProjectionClientToRuntimeMessage {
@@ -42,9 +42,9 @@ message ProjectionRegistrationResponse {
 
 message ProjectionRequest {
     services.ReverseCallRequestContext callContext = 1;
-    StreamEvent event = 2;
-    RetryProcessingState retryProcessingState = 3;
-    // TODO: Add projection state here
+    string previousState = 2;
+    StreamEvent event = 3;
+    RetryProcessingState retryProcessingState = 4;
 }
 
 message ProjectionRuntimeToClientMessage {


### PR DESCRIPTION
This service definition (with messages) uses the same _reverse call_ protocol that we use for Event Handlers and Filters.

The current suggestion is meant to support:
1. Registering a projection by:
   - ID
   - Initial state (JSON string) that is used when a projection is first created (first event occurs for a _key_)
   - Selected events, by event type and _key_ selector. Currently we support keys from:
     - EventSourceId
     - PartitionId
     - A named property on the event content
2. Calculating new projection state as events occur. The key will be deduced by the Runtime, and along with the event the Runtime will send to the head the current (or initial) state for the projection with that key. The Head can then reply with either:
   - A `REPLACE` result, which overwrites the current state of the projection instance with the value provided
   - A `DELETE` result which deletes the projection instance. A new event with the same key would re-create the projection instance from initial state.

The suggestion is somewhat generic in terms of _key selector_ and _next state_ types, so we can if we want to allow more flexible or complex ways without breaking the Contracts in the future.