### PR TITLE
Fix js contracts release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Establish context
         id: context
-        uses: dolittle/establish-context-action@v2 # Replace with ./ if used withing dolittle/establish-context-action
+        uses: dolittle/establish-context-action@v2
         with:
           prerelease-branches: ${{ env.PRERELEASE_BRANCHES }}
       - name: Increment version
         id: increment-version
         if: ${{ steps.context.outputs.should-publish == 'true' }}
-        uses: dolittle/increment-version-action@v2 # Replace with ./ if used withing dolittle/increment-version-action
+        uses: dolittle/increment-version-action@v2
         with:
           version: ${{ steps.context.outputs.current-version }}
           release-type: ${{ steps.context.outputs.release-type }}
@@ -67,7 +67,7 @@ jobs:
           user-email: build@dolittle.com
           user-name: dolittle-build
       - name: Create GitHub Release
-        uses: dolittle/github-release-action@v2 # Replace with ./ if used withing dolittle/github-release-action
+        uses: dolittle/github-release-action@v2
         with:
           version: ${{ needs.context.outputs.version }}
           body: ${{ needs.context.outputs.pr-body }}
@@ -88,51 +88,59 @@ jobs:
         run: dotnet pack --configuration Release -o Artifacts/NuGet /p:PackageVersion=${{ needs.context.outputs.version }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -p:NoDefaultExcludes=true
       - name: Push NuGet packages
         run: dotnet nuget push 'Artifacts/NuGet/*.nupkg' --skip-duplicate --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-  # java-script:
-  #   name: JavaScript
-  #   runs-on: ubuntu-latest
-  #   needs: context
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: actions/setup-node@v1
-  #     with:
-  #       node-version: 12.x
-  #   - uses: arduino/setup-protoc@master
-  #     with:
-  #       version: '3.11.2'
-  #   - name: Install dependencies
-  #     working-directory: ./Generation
-  #     run: yarn
-  #   - name: Build Fundamentals
-  #     working-directory: ./Generation/Fundamentals/JavaScript
-  #     run: yarn build
-  #   - name: Build Fundamentals Web
-  #     working-directory: ./Generation/Fundamentals/JavaScript.Web
-  #     run: yarn build
-  #   - name: Build Runtime
-  #     working-directory: ./Generation/Runtime/JavaScript
-  #     run: yarn build
-  #   - name: Build Runtime Web
-  #     working-directory: ./Generation/Runtime/JavaScript.Web
-  #     run: yarn build
-  #   - name: Publish Fundamentals
-  #     if: ${{ success() && needs.context.outputs.should-publish == 'true' }}
-  #     working-directory: ./Generation/Fundamentals/JavaScript
-  #     run: yarn publish --new-version ${{ needs.context.outputs.version }} --no-git-tag-version
-  #   - name: Publish Fundamentals Web
-  #     if: ${{ success() && needs.context.outputs.should-publish == 'true' }}
-  #     working-directory: ./Generation/Fundamentals/JavaScript.Web
-  #     run: yarn publish --new-version ${{ needs.context.outputs.version }} --no-git-tag-version
-  #   - name: Publish Runtime
-  #     if: ${{ success() && needs.context.outputs.should-publish == 'true' }}
-  #     working-directory: ./Generation/Runtime/JavaScript
-  #     run: yarn publish --new-version ${{ needs.context.outputs.version }} --no-git-tag-version
-  #   - name: Publish Runtime Web
-  #     if: ${{ success() && needs.context.outputs.should-publish == 'true' }}
-  #     working-directory: ./Generation/Runtime/JavaScript.Web
-  #     run: yarn publish --new-version ${{ needs.context.outputs.version }} --no-git-tag-version
-  #   - name: Create Pull Request
-  #     if: ${{ success() && needs.context.outputs.should-publish == 'true' }}
-  #     uses: peter-evans/create-pull-request@v2
-  #     with:
-  #       title: Bump package.json versions to ${{ needs.context.outputs.version }}
+
+  java-script:
+    name: JavaScript
+    runs-on: ubuntu-latest
+    needs: context
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+        registry-url: 'https://registry.npmjs.org'
+    - uses: arduino/setup-protoc@master
+      with:
+        version: '3.11.2'
+    - name: Install dependencies
+      working-directory: ./Generation
+      run: yarn
+
+    
+    - name: Parse semver string
+      id: semver_parser
+      uses: booxmedialtd/ws-action-parse-semver@v1
+      with:
+        input_string: ${{ needs.context.outputs.version }}
+
+    - name: Build Fundamentals
+      working-directory: ./Generation/Fundamentals/JavaScript
+      run: yarn build
+    - name: Update Fundamentals version
+      working-directory: ./Generation/Fundamentals/JavaScript
+      run: npm version ${{ needs.context.outputs.version }}
+
+    # - name: Build Fundamentals - Web
+    #   working-directory: ./Generation/Fundamentals/JavaScript.Web
+    #   run: yarn build
+
+    - name: Build Runtime
+      working-directory: ./Generation/Runtime/JavaScript
+      run: yarn build
+    - name: Update Runtime version
+      working-directory: ./Generation/Runtime/JavaScript
+      run: npm version ${{ needs.context.outputs.version }}
+
+    # - name: Build Runtime - Web
+    #   working-directory: ./Generation/Runtime/JavaScript.Web
+    #   run: yarn build
+
+    - name: Publish Fundamentals
+      if: ${{ needs.context.outputs.should-publish == 'true' }}
+      working-directory: ./Generation/Fundamentals/JavaScript
+      run: npm publish --tag ${{ needs.context.outputs.release-type == 'prerelease' && ${{ steps.semver_parser.outputs.prerelease }} || 'latest' }}
+    - name: Publish Runtime
+      if: ${{ needs.context.outputs.should-publish == 'true' }}
+      working-directory: ./Generation/Runtime/JavaScript
+      run: npm publish --tag ${{ needs.context.outputs.release-type == 'prerelease' && ${{ steps.semver_parser.outputs.prerelease }} || 'latest' }}
+

--- a/Generation/Fundamentals/CSharp/CSharp.csproj
+++ b/Generation/Fundamentals/CSharp/CSharp.csproj
@@ -8,6 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="1.1.1"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="2.0.6"/>
     </ItemGroup>
 </Project>

--- a/Generation/Fundamentals/JavaScript.Web/package.json
+++ b/Generation/Fundamentals/JavaScript.Web/package.json
@@ -30,7 +30,7 @@
     "types": "index.d.ts",
     "typings": "index.d.ts",
     "scripts": {
-        "build": "npx dolittle_proto_build grpc-web -I../../../Source  ../../../Source/Fundamentals",
+        "build": "dolittle_proto_build grpc-web -I../../../Source  ../../../Source/Fundamentals",
         "prepublish": "yarn build"
     },
     "dependencies": {

--- a/Generation/Fundamentals/JavaScript.Web/package.json
+++ b/Generation/Fundamentals/JavaScript.Web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dolittle/contracts.web",
     "description": "Grpc services for Dolittle Runtime for grpc-web",
-    "version": "5.1.20",
+    "version": "0.0.0",
     "homepage": "https://dolittle.io",
     "author": "Dolittle",
     "license": "MIT",

--- a/Generation/Fundamentals/JavaScript/package.json
+++ b/Generation/Fundamentals/JavaScript/package.json
@@ -30,9 +30,10 @@
     "types": "index.d.ts",
     "typings": "index.d.ts",
     "scripts": {
-        "build": "npx dolittle_proto_build grpc-node -I../../../Source  ../../../Source/Fundamentals",
+        "build": "dolittle_proto_build grpc-node -I../../../Source  ../../../Source/Fundamentals",
         "prepublish": "yarn build"
     },
+
     "dependencies": {
         "@grpc/grpc-js": "^1.2.0",
         "@types/google-protobuf": "^3.2.7",

--- a/Generation/Fundamentals/JavaScript/package.json
+++ b/Generation/Fundamentals/JavaScript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dolittle/contracts",
     "description": "Grpc services for Dolittle Fundamentals",
-    "version": "5.1.20",
+    "version": "0.0.0",
     "homepage": "https://dolittle.io",
     "author": "Dolittle",
     "license": "MIT",
@@ -33,7 +33,6 @@
         "build": "dolittle_proto_build grpc-node -I../../../Source  ../../../Source/Fundamentals",
         "prepublish": "yarn build"
     },
-
     "dependencies": {
         "@grpc/grpc-js": "^1.2.0",
         "@types/google-protobuf": "^3.2.7",

--- a/Generation/Runtime/CSharp/CSharp.csproj
+++ b/Generation/Runtime/CSharp/CSharp.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="1.1.1"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="2.0.6"/>
     </ItemGroup>
     
 </Project>

--- a/Generation/Runtime/JavaScript.Web/package.json
+++ b/Generation/Runtime/JavaScript.Web/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dolittle/runtime.contracts.web",
     "description": "Grpc services for Dolittle Runtime for grpc-web",
-    "version": "5.1.20",
+    "version": "0.0.0",
     "homepage": "https://dolittle.io",
     "author": "Dolittle",
     "license": "MIT",

--- a/Generation/Runtime/JavaScript.Web/package.json
+++ b/Generation/Runtime/JavaScript.Web/package.json
@@ -30,7 +30,7 @@
     "types": "index.d.ts",
     "typings": "index.d.ts",
     "scripts": {
-        "build": "npx dolittle_proto_build grpc-web -I../../../Source ../../../Source/Fundamentals ../../../Source/Runtime",
+        "build": "dolittle_proto_build grpc-web -I../../../Source ../../../Source/Fundamentals ../../../Source/Runtime",
         "prepublish": "yarn build"
     },
     "dependencies": {

--- a/Generation/Runtime/JavaScript/package.json
+++ b/Generation/Runtime/JavaScript/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dolittle/runtime.contracts",
     "description": "Grpc services for Dolittle Runtime",
-    "version": "5.1.20",
+    "version": "0.0.0",
     "homepage": "https://dolittle.io",
     "author": "Dolittle",
     "license": "MIT",

--- a/Generation/Runtime/JavaScript/package.json
+++ b/Generation/Runtime/JavaScript/package.json
@@ -30,7 +30,7 @@
     "types": "index.d.ts",
     "typings": "index.d.ts",
     "scripts": {
-        "build": "npx dolittle_proto_build grpc-node -I../../../Source  ../../../Source/Fundamentals ../../../Source/Runtime",
+        "build": "dolittle_proto_build grpc-node -I../../../Source  ../../../Source/Fundamentals ../../../Source/Runtime",
         "prepublish": "yarn build"
     },
     "dependencies": {

--- a/Generation/package.json
+++ b/Generation/package.json
@@ -5,7 +5,7 @@
     "Runtime/*"
   ],
   "devDependencies": {
-    "@dolittle/protobuf.build": "2.0.1",
+    "@dolittle/protobuf.build": "2.0.6",
     "typescript": "^3.8.3"
   }
 }


### PR DESCRIPTION
## Summary

Updated references to Dolittle Protobuf libraries, and added JS building and publishing back to workflow.

### Added

- JS build + publish in GitHub workflow

### Changed

- Updated Dolittle Protobuf library versions
