### PR TITLE
Fix go release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [dot-net-build, context]
+    needs: [context, dot-net-build, java-script-build, golang-build]
     if: ${{ needs.context.outputs.should-publish == 'true' }}
     steps:
       - uses: actions/checkout@v2
@@ -110,7 +110,7 @@ jobs:
   dot-net-release:
     name: .Net Release
     runs-on: ubuntu-latest
-    needs: [context, dot-net-build]
+    needs: [context, release]
     if: ${{ needs.context.outputs.should-publish == 'true' }}
     steps:
       - uses: actions/checkout@v2
@@ -129,7 +129,7 @@ jobs:
   java-script-release:
     name: JavaScript Release
     runs-on: ubuntu-latest
-    needs: [context, java-script-build]
+    needs: [context, release]
     if: ${{ needs.context.outputs.should-publish == 'true' }}
     steps:
     - uses: actions/checkout@v2
@@ -175,7 +175,7 @@ jobs:
   golang-release:
     name: Go Release
     runs-on: ubuntu-latest
-    needs: [context, golang-build]
+    needs: [context, release]
     if: ${{ needs.context.outputs.should-publish == 'true' }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         repository: dolittle/Go.Contracts
+        token: ${{ secrets.BUILD_PAT }}
         path: ./Generation/Go/output
     - name: Cleanout old released code
       working-directory: ./Generation/Go/output


### PR DESCRIPTION
## Summary

Checkout dolittle/Go.Contracts using the build token, and changed workflow to only release if all builds succeed.

### Added

- Checkout dolittle/Go.Contracts with build token

### Changed

- Only release if all builds succeed
