### PR TITLE
Delete directories when cleaning out Go code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         path: ./Generation/Go/output
     - name: Cleanout old released code
       working-directory: ./Generation/Go/output
-      run: rm * && git checkout -- README.md LICENSE
+      run: rm -r * && git checkout -- README.md LICENSE
     - name: Copy new generated code
       working-directory: ./Generation/Go/
       run: cp -r generated/* output


### PR DESCRIPTION
## Summary

Fix Go release workflow to work more than once.

### Fixed

- Was not removing directories while cleaning out old generated Go code, changed to `rm -r *`