### PR TITLE
Allow empty commits when releasing Go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
         git config user.name "Contracts Release GitHub Actions"
         git config user.email "contracts-release@dolittle.com"
         git add .
-        git commit -m "Generated code for ${{ needs.context.outputs.version }}"
+        git commit --allow-empty -m "Generated code for ${{ needs.context.outputs.version }}"
         git tag "v${{ needs.context.outputs.version }}"
         git push
         git push --tags


### PR DESCRIPTION
## Summary

Fixed releasing of Go generated code when nothing has changed.

### Fixed

- Use `git commit --allow-empty ...` to release a new Go version even if nothing has changed