### PR TITLE
Add service for embeddings

### DIFF
--- a/Source/Runtime/Embeddings/Embeddings.proto
+++ b/Source/Runtime/Embeddings/Embeddings.proto
@@ -5,6 +5,7 @@ syntax = "proto3";
 
 import "Fundamentals/Protobuf/Uuid.proto";
 import "Fundamentals/Protobuf/Failure.proto";
+import "Fundamentals/Services/CallContext.proto";
 import "Fundamentals/Services/ReverseCallContext.proto";
 import "Fundamentals/Services/Ping.proto";
 import "Runtime/Events/Uncommitted.proto";

--- a/Source/Runtime/Embeddings/Embeddings.proto
+++ b/Source/Runtime/Embeddings/Embeddings.proto
@@ -1,0 +1,97 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+syntax = "proto3";
+
+import "Fundamentals/Protobuf/Uuid.proto";
+import "Fundamentals/Protobuf/Failure.proto";
+import "Fundamentals/Services/ReverseCallContext.proto";
+import "Fundamentals/Services/Ping.proto";
+import "Runtime/Events/Uncommitted.proto";
+import "Runtime/Events.Processing/Projections.proto";
+import "Runtime/Projections/State.proto";
+
+package dolittle.runtime.embeddings;
+
+option csharp_namespace = "Dolittle.Runtime.Embeddings.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/embeddings";
+
+message EmbeddingRegistrationRequest {
+    services.ReverseCallArgumentsContext callContext = 1;
+    protobuf.Uuid embeddingId = 2;
+    repeated events.processing.ProjectionEventSelector events = 3;
+    string initialState = 4;
+}
+
+message EmbeddingResponse {
+    services.ReverseCallResponseContext callContext = 1;
+    repeated events.UncommittedEvent events = 2;
+    protobuf.Failure failure = 3; // If not set/empty - no failure
+}
+
+message EmbeddingClientToRuntimeMessage {
+    oneof Message {
+        EmbeddingRegistrationRequest registrationRequest = 1;
+        EmbeddingResponse handleEmbeddingResult = 2;
+        events.processing.ProjectionResponse handleProjectionResult = 3;
+        services.Pong pong = 4;
+    }
+}
+
+message EmbeddingRegistrationResponse {
+    protobuf.Failure failure = 1; // If not set/empty - no failure
+}
+
+message EmbeddingCompareRequest {
+    string entityState = 1;
+    projections.ProjectionCurrentState projectionState = 2;
+}
+
+message EmbeddingDeleteRequest {
+    projections.ProjectionCurrentState projectionState = 1;
+}
+
+message EmbeddingRequest {
+    services.ReverseCallRequestContext callContext = 1;
+    oneof Request {
+        EmbeddingCompareRequest compare = 2;
+        EmbeddingDeleteRequest delete = 3;
+    }
+}
+
+message EmbeddingRuntimeToClientMessage {
+    oneof Message {
+        EmbeddingRegistrationResponse registrationResponse = 1;
+        EmbeddingRequest handleEmbeddingRequest = 2;
+        events.processing.ProjectionRequest handleProjectionRequest = 3;
+        services.Ping ping = 4;
+    }
+}
+
+message UpdateRequest {
+    services.CallRequestContext callContext = 1;
+    protobuf.Uuid embeddingId = 2;
+    string key = 3;
+    string state = 4;
+}
+
+message UpdateResponse {
+    projections.ProjectionCurrentState state = 1;
+    protobuf.Failure failure = 2; // If not set/empty - no failure
+}
+
+message DeleteRequest {
+    services.CallRequestContext callContext = 1;
+    protobuf.Uuid embeddingId = 2;
+    string key = 3;
+}
+
+message DeleteResponse {
+    protobuf.Failure failure = 1; // If not set/empty - no failure
+}
+
+service Embeddings {
+    rpc Connect(stream EmbeddingClientToRuntimeMessage) returns(stream EmbeddingRuntimeToClientMessage);
+    rpc Update(UpdateRequest) returns (UpdateResponse);
+    rpc Delete(DeleteRequest) returns (DeleteResponse);
+}


### PR DESCRIPTION
## Summary

Added an embeddings service, that has three endpoints:

#### Connect, for registering an embedding:
An embedding is an extension of a projection (only allowed on the default scope), that also handles _compare_ requests.
When the external state of an embedding changes, the embedding will be called to compare the externally provided state and the current state of the projection that has the same key. The method is expected to return a set of events that move the projection state closer to the external state. These events are committed and used to update the projection. This process will be repeated until the external and projection states are equal.

#### Update, for asking the runtime to start an update process:
At any time, the runtime can be called with a state for a given embedding id and key. If the state is not equal to the current state, the process described above will kick in. When the states are equal, the runtime will reply with the projected state. If it is not possible to reach the provided state for the specified embedding, the runtime will reply with a failure and not commit any events.


#### Delete, for asking the runtime to start an update process that results in a deletion:
This endpoint triggers the same behaviour as the Update endpoint, but where the desired state is that the given embedding id and key should not exist.

> Note: for getting the current state of embeddings, the projections endpoint can be used with the embedding id as the state of embeddings are stored using projections.

### Added

- Service for registering an embedding, and for updating and deleting the state