### PR TITLE
Add Embedding store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,5 @@ Generation/JavaScript/Runtime/**
 
 Generation/Go/*
 !Generation/Go/generate.sh
+
+Generation/Artifacts

--- a/Source/Runtime/Embeddings/Store.proto
+++ b/Source/Runtime/Embeddings/Store.proto
@@ -35,7 +35,7 @@ message GetAllResponse {
 }
 
 // Represents the Embeddings store service
-service Embeddings {
+service EmbeddingsStore {
     rpc GetOne(GetOneRequest) returns(GetOneResponse);
     rpc GetAll(GetAllRequest) returns(GetAllResponse);
 }

--- a/Source/Runtime/Embeddings/Store.proto
+++ b/Source/Runtime/Embeddings/Store.proto
@@ -8,31 +8,29 @@ import "Fundamentals/Protobuf/Uuid.proto";
 import "Fundamentals/Services/CallContext.proto";
 import "Runtime/Projections/State.proto";
 
-package dolittle.runtime.projections;
+package dolittle.runtime.embeddings;
 
-option csharp_namespace = "Dolittle.Runtime.Projections.Contracts";
-option go_package = "go.dolittle.io/contracts/runtime/projections";
+option csharp_namespace = "Dolittle.Runtime.Embeddings.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/embeddings";
 
 message GetOneRequest {
     services.CallRequestContext callContext = 1; 
-    protobuf.Uuid scopeId = 2;
-    protobuf.Uuid projectionId = 3;
-    string key = 4;
+    protobuf.Uuid embeddingId = 2;
+    string key = 3;
 }
 
 message GetAllRequest {
     services.CallRequestContext callContext = 1; 
-    protobuf.Uuid scopeId = 2;
-    protobuf.Uuid projectionId = 3;
+    protobuf.Uuid embeddingId = 2;
 }
 
 message GetOneResponse {
-    ProjectionCurrentState state = 1;
+    projections.ProjectionCurrentState state = 1;
     protobuf.Failure failure = 2; // not set if not failed
 }
 
 message GetAllResponse {
-    repeated ProjectionCurrentState states = 1;
+    repeated projections.ProjectionCurrentState states = 1;
     protobuf.Failure failure = 2; // not set if not failed
 }
 

--- a/Source/Runtime/Embeddings/Store.proto
+++ b/Source/Runtime/Embeddings/Store.proto
@@ -34,8 +34,8 @@ message GetAllResponse {
     protobuf.Failure failure = 2; // not set if not failed
 }
 
-// Represents the Projections service
-service Projections {
+// Represents the Embeddings store service
+service Embeddings {
     rpc GetOne(GetOneRequest) returns(GetOneResponse);
     rpc GetAll(GetAllRequest) returns(GetAllResponse);
 }


### PR DESCRIPTION
- Mostly a copypasta from _Projections/Store_
- Removed `ScopeId` from the requests (not needed for embeddings)
- Added the untracked _Generation/Artifacts_ folder to `.gitignore`. I think that folder is just automatically created by `dotnet build`, and it only contains the generated doc `.xml` file.

I also now realised, that we have structured this differently from Projections. The `Projections.proto` files with the registration code is inside _Events.Processing_ folder, not _Projections_. Maybe `Embeddings.proto` should then also get moved to _Events.Processing_?