### PR TITLE
Change to uncommitted events

### DIFF
--- a/Source/Runtime/Embeddings/Embeddings.proto
+++ b/Source/Runtime/Embeddings/Embeddings.proto
@@ -71,17 +71,17 @@ message EmbeddingDeleteRequest {
     projections.ProjectionCurrentState projectionState = 1;
 }
 
+message EmbeddingProjectRequest {
+    projections.ProjectionCurrentState currentState = 1;
+    events.UncommittedEvent event = 2;
+}
+
 message EmbeddingRequest {
-    message ProjectionRequest {
-        projections.ProjectionCurrentState currentState = 1;
-        events.processing.StreamEvent event = 2;
-        events.processing.RetryProcessingState retryProcessingState = 3;
-    }
     services.ReverseCallRequestContext callContext = 1;
     oneof Request {
         EmbeddingCompareRequest compare = 2;
         EmbeddingDeleteRequest delete = 3;
-        ProjectionRequest projection = 4;
+        EmbeddingProjectRequest projection = 4;
     }
 }
 

--- a/Source/Runtime/Embeddings/Store.proto
+++ b/Source/Runtime/Embeddings/Store.proto
@@ -19,6 +19,11 @@ message GetOneRequest {
     string key = 3;
 }
 
+message GetKeysRequest {
+    services.CallRequestContext callContext = 1; 
+    protobuf.Uuid embeddingId = 2;
+}
+
 message GetAllRequest {
     services.CallRequestContext callContext = 1; 
     protobuf.Uuid embeddingId = 2;
@@ -26,6 +31,11 @@ message GetAllRequest {
 
 message GetOneResponse {
     projections.ProjectionCurrentState state = 1;
+    protobuf.Failure failure = 2; // not set if not failed
+}
+
+message GetKeysResponse {
+    repeated string keys = 1;
     protobuf.Failure failure = 2; // not set if not failed
 }
 
@@ -37,5 +47,6 @@ message GetAllResponse {
 // Represents the Embeddings store service
 service EmbeddingsStore {
     rpc GetOne(GetOneRequest) returns(GetOneResponse);
+    rpc GetKeys(GetKeysRequest) returns(GetKeysResponse);
     rpc GetAll(GetAllRequest) returns(GetAllResponse);
 }

--- a/Source/Runtime/Embeddings/Store.proto
+++ b/Source/Runtime/Embeddings/Store.proto
@@ -44,8 +44,8 @@ message GetAllResponse {
     protobuf.Failure failure = 2; // not set if not failed
 }
 
-// Represents the Embeddings store service
-service EmbeddingsStore {
+// Represents the Embedding Store service
+service EmbeddingStore {
     rpc GetOne(GetOneRequest) returns(GetOneResponse);
     rpc GetKeys(GetKeysRequest) returns(GetKeysResponse);
     rpc GetAll(GetAllRequest) returns(GetAllResponse);


### PR DESCRIPTION
## Summary

Firstly, I have added a method for getting all the keys for an Embedding from the EmbeddingStore, this is most likely the call that will be used externally (to figure out what to delete), and should save a bit of time and effort for doing that.

Secondly, I change the event we are sending over to the Head when projecting an event to be an UncommittedEvent. We are going to be projecting both uncommitted and committed events, so the least common structure would be the uncommitted event. This means that there will be less available information about the event itself (as it has not been stored yet), but still most of what we need (ExecutionContect) will still be in the ReverseCallRequestContext.

### Added

- Method for getting all keys for an Embedding. This will be useful to have, and should save some time for a few operations.

### Changed

- From a StreamEvent to UncommittedEvent when asking the Head to project an event in an Embedding.
- `EmbeddingsStore` -> `EmbeddingStore` to be consistent with e.g. `EventStore`.
