### PR TITLE
Gimli: SDK <-> Runtime Handshake and build time VersionInfo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       pr-body: ${{ steps.context.outputs.pr-body }}
       pr-url: ${{ steps.context.outputs.pr-url }}
       version: ${{ steps.increment-version.outputs.next-version }}
+      versioninfo-version: ${{ steps.increment-version.outputs.next-version || '0.0.0-norelease' }}
       release-type: ${{ steps.context.outputs.release-type }}
     steps:
       - uses: actions/checkout@v2
@@ -47,7 +48,7 @@ jobs:
       - name: Update VersionInfo
         uses: dolittle/update-version-info-action@v1
         with:
-          version: ${{ needs.context.outputs.version }}
+          version: ${{ needs.context.outputs.versioninfo-version }}
           files-to-update: |
             Generation/CSharp/Fundamentals/VersionInfo.cs
             Generation/CSharp/Runtime/VersionInfo.cs
@@ -70,7 +71,7 @@ jobs:
       - name: Update VersionInfo
         uses: dolittle/update-version-info-action@v1
         with:
-          version: ${{ needs.context.outputs.version }}
+          version: ${{ needs.context.outputs.versioninfo-version }}
           files-to-update: |
             Generation/JavaScript/Fundamentals/VersionInfo.js
             Generation/JavaScript/Runtime/VersionInfo.js
@@ -97,7 +98,7 @@ jobs:
       - name: Update VersionInfo
         uses: dolittle/update-version-info-action@v1
         with:
-          version: ${{ needs.context.outputs.version }}
+          version: ${{ needs.context.outputs.versioninfo-version }}
           files-to-update: |
             Generation/Go/template/VersionInfo.go
       - name: Generate code
@@ -140,7 +141,7 @@ jobs:
       - name: Update VersionInfo
         uses: dolittle/update-version-info-action@v1
         with:
-          version: ${{ needs.context.outputs.version }}
+          version: ${{ needs.context.outputs.versioninfo-version }}
           files-to-update: |
             Generation/CSharp/Fundamentals/VersionInfo.cs
             Generation/CSharp/Runtime/VersionInfo.cs
@@ -170,7 +171,7 @@ jobs:
       - name: Update VersionInfo
         uses: dolittle/update-version-info-action@v1
         with:
-          version: ${{ needs.context.outputs.version }}
+          version: ${{ needs.context.outputs.versioninfo-version }}
           files-to-update: |
             Generation/JavaScript/Fundamentals/VersionInfo.js
             Generation/JavaScript/Runtime/VersionInfo.js
@@ -223,7 +224,7 @@ jobs:
       - name: Update VersionInfo
         uses: dolittle/update-version-info-action@v1
         with:
-          version: ${{ needs.context.outputs.version }}
+          version: ${{ needs.context.outputs.versioninfo-version }}
           files-to-update: |
             Generation/Go/template/VersionInfo.go
       - name: Generate code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,13 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "3.1.x"
+      - name: Update VersionInfo
+        uses: dolittle/update-version-info-action@v1
+        with:
+          version: ${{ needs.context.outputs.version }}
+          files-to-update: |
+            Generation/CSharp/Fundamentals/VersionInfo.cs
+            Generation/CSharp/Runtime/VersionInfo.cs
       - run: dotnet build -c Release
         working-directory: ./Generation/CSharp
 
@@ -60,6 +67,13 @@ jobs:
       - name: Install dependencies
         working-directory: ./Generation/JavaScript
         run: yarn
+      - name: Update VersionInfo
+        uses: dolittle/update-version-info-action@v1
+        with:
+          version: ${{ needs.context.outputs.version }}
+          files-to-update: |
+            Generation/JavaScript/Fundamentals/VersionInfo.js
+            Generation/JavaScript/Runtime/VersionInfo.js
       - name: Build Fundamentals
         working-directory: ./Generation/JavaScript/Fundamentals
         run: yarn build
@@ -80,6 +94,12 @@ jobs:
         with:
           version: "3.18.1"
       - run: go get google.golang.org/protobuf/cmd/protoc-gen-go google.golang.org/grpc/cmd/protoc-gen-go-grpc
+      - name: Update VersionInfo
+        uses: dolittle/update-version-info-action@v1
+        with:
+          version: ${{ needs.context.outputs.version }}
+          files-to-update: |
+            Generation/Go/template/VersionInfo.go
       - name: Generate code
         working-directory: ./Generation/Go
         run: ./generate.sh ${{ needs.context.outputs.version }}
@@ -117,6 +137,13 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: "3.1.x"
+      - name: Update VersionInfo
+        uses: dolittle/update-version-info-action@v1
+        with:
+          version: ${{ needs.context.outputs.version }}
+          files-to-update: |
+            Generation/CSharp/Fundamentals/VersionInfo.cs
+            Generation/CSharp/Runtime/VersionInfo.cs
       - run: dotnet build
         working-directory: ./Generation/CSharp
       - name: Create packages
@@ -140,6 +167,13 @@ jobs:
       - name: Install dependencies
         working-directory: ./Generation/JavaScript
         run: yarn
+      - name: Update VersionInfo
+        uses: dolittle/update-version-info-action@v1
+        with:
+          version: ${{ needs.context.outputs.version }}
+          files-to-update: |
+            Generation/JavaScript/Fundamentals/VersionInfo.js
+            Generation/JavaScript/Runtime/VersionInfo.js
       - name: Build Fundamentals
         working-directory: ./Generation/JavaScript/Fundamentals
         run: yarn build
@@ -186,6 +220,12 @@ jobs:
         with:
           version: "3.18.1"
       - run: go get google.golang.org/protobuf/cmd/protoc-gen-go google.golang.org/grpc/cmd/protoc-gen-go-grpc
+      - name: Update VersionInfo
+        uses: dolittle/update-version-info-action@v1
+        with:
+          version: ${{ needs.context.outputs.version }}
+          files-to-update: |
+            Generation/Go/template/VersionInfo.go
       - name: Generate code
         working-directory: ./Generation/Go
         run: ./generate.sh ${{ needs.context.outputs.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Contracts CI/CD
 
 env:
-  PRERELEASE_BRANCHES: legolas # Comma separated list of prerelease branch names. 'alpha,rc, ...'
+  PRERELEASE_BRANCHES: gimli # Comma separated list of prerelease branch names. 'alpha,rc, ...'
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -349,7 +349,6 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 
-
 yarn.lock
 package-json.lock
 *.cs

--- a/Generation/CSharp/Fundamentals/Fundamentals.csproj
+++ b/Generation/CSharp/Fundamentals/Fundamentals.csproj
@@ -9,6 +9,6 @@
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.3.0"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.3.1"/>
     </ItemGroup>
 </Project>

--- a/Generation/CSharp/Fundamentals/Fundamentals.csproj
+++ b/Generation/CSharp/Fundamentals/Fundamentals.csproj
@@ -4,10 +4,11 @@
         <AssemblyName>Dolittle.Contracts</AssemblyName>
         <DolittleProtoProject>../../../Source/Fundamentals</DolittleProtoProject>
         <DolittleProtoRoot>../../../Source</DolittleProtoRoot>
+        <DolittleProtoKeepFiles>VersionInfo.cs</DolittleProtoKeepFiles>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.3.0"/>
     </ItemGroup>
 </Project>

--- a/Generation/CSharp/Fundamentals/VersionInfo.cs
+++ b/Generation/CSharp/Fundamentals/VersionInfo.cs
@@ -15,10 +15,10 @@ namespace Dolittle.Contracts
         /// </summary>
         public static Version CurrentVersion { get; } = new Version
         {
-            Major = 100,
-            Minor = 200,
-            Patch = 300,
-            PreReleaseString = "LOCAL",
+            Major = 377,
+            Minor = 389,
+            Patch = 368,
+            PreReleaseString = "PRERELEASE",
         };
     }
 }

--- a/Generation/CSharp/Fundamentals/VersionInfo.cs
+++ b/Generation/CSharp/Fundamentals/VersionInfo.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Versioning.Contracts;
+
+namespace Dolittle.Contracts
+{
+    /// <summary>
+    /// Provides information about the current version of the Contracts.
+    /// </summary>
+    public static class VersionInfo
+    {
+        /// <summary>
+        /// Gets the the current <see cref="Version"/> of the Contracts.
+        /// </summary>
+        public static Version CurrentVersion { get; } = new Version
+        {
+            Major = 100,
+            Minor = 200,
+            Patch = 300,
+            PreReleaseString = "LOCAL",
+        };
+    }
+}

--- a/Generation/CSharp/Runtime/Runtime.csproj
+++ b/Generation/CSharp/Runtime/Runtime.csproj
@@ -4,15 +4,15 @@
         <AssemblyName>Dolittle.Runtime.Contracts</AssemblyName>
         <DolittleProtoProject>../../../Source/Runtime</DolittleProtoProject>
         <DolittleProtoRoot>../../../Source</DolittleProtoRoot>
+        <DolittleProtoKeepFiles>VersionInfo.cs</DolittleProtoKeepFiles>
     </PropertyGroup>
-    
+
     <ItemGroup>
         <ProjectReference Include="../Fundamentals/Fundamentals.csproj" />
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.3.0"/>
     </ItemGroup>
-    
 </Project>

--- a/Generation/CSharp/Runtime/Runtime.csproj
+++ b/Generation/CSharp/Runtime/Runtime.csproj
@@ -13,6 +13,6 @@
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.3.0"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.3.1"/>
     </ItemGroup>
 </Project>

--- a/Generation/CSharp/Runtime/VersionInfo.cs
+++ b/Generation/CSharp/Runtime/VersionInfo.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Dolittle.Versioning.Contracts;
+
+namespace Dolittle.Runtime.Contracts
+{
+    /// <summary>
+    /// Provides information about the current version of the Runtime Contracts.
+    /// </summary>
+    public static class VersionInfo
+    {
+        /// <summary>
+        /// Gets the the current <see cref="Version"/> of the Runtime Contracts.
+        /// </summary>
+        public static Version CurrentVersion { get; } = new Version
+        {
+            Major = 100,
+            Minor = 200,
+            Patch = 300,
+            PreReleaseString = "LOCAL",
+        };
+    }
+}

--- a/Generation/CSharp/Runtime/VersionInfo.cs
+++ b/Generation/CSharp/Runtime/VersionInfo.cs
@@ -15,10 +15,10 @@ namespace Dolittle.Runtime.Contracts
         /// </summary>
         public static Version CurrentVersion { get; } = new Version
         {
-            Major = 100,
-            Minor = 200,
-            Patch = 300,
-            PreReleaseString = "LOCAL",
+            Major = 377,
+            Minor = 389,
+            Patch = 368,
+            PreReleaseString = "PRERELEASE",
         };
     }
 }

--- a/Generation/Go/generate.sh
+++ b/Generation/Go/generate.sh
@@ -45,7 +45,13 @@ find ./versioned -name '*.proto' | while read PROTOFILE; do
 done
 
 echo "Copying template Go code..."
-cp -Rv template/* generated/
+TEMPLATE_DIRECTORY="./template"
+IMPORT_PACKAGE_PATTERN='("go.dolittle.io\/contracts)(\/[^"]*")'
+find "$TEMPLATE_DIRECTORY" -name '*.go' | while read GOFILE; do
+    OUTFILE="./generated/$(realpath --relative-to="$TEMPLATE_DIRECTORY" "$GOFILE")"
+    sed -r "s/$IMPORT_PACKAGE_PATTERN/\1\/v$MAJOR_VERSION\2/g" "./$GOFILE" > "$OUTFILE"
+    echo "Copied template with replaced import for $GOFILE"
+done
 
 echo "Initializing Go module and resolving dependencies..."
 cd ./generated

--- a/Generation/Go/generate.sh
+++ b/Generation/Go/generate.sh
@@ -44,6 +44,9 @@ find ./versioned -name '*.proto' | while read PROTOFILE; do
     echo "Generated code Go for $PROTOFILE"
 done
 
+echo "Copying template Go code..."
+cp -Rv template/* generated/
+
 echo "Initializing Go module and resolving dependencies..."
 cd ./generated
 go mod init "go.dolittle.io/contracts/v$MAJOR_VERSION"

--- a/Generation/Go/template/VersionInfo.go
+++ b/Generation/Go/template/VersionInfo.go
@@ -1,0 +1,15 @@
+package contracts
+
+import (
+	"go.dolittle.io/contracts/v6/versioning"
+)
+
+// GetCurrentVersion returns the current version of the Contracts.
+func GetCurrentVersion() versioning.Version {
+	return versioning.Version{
+		Major:            100,
+		Minor:            200,
+		Patch:            300,
+		PreReleaseString: "LOCAL",
+	}
+}

--- a/Generation/Go/template/VersionInfo.go
+++ b/Generation/Go/template/VersionInfo.go
@@ -1,7 +1,7 @@
 package contracts
 
 import (
-	"go.dolittle.io/contracts/v6/versioning"
+	"go.dolittle.io/contracts/versioning"
 )
 
 // GetCurrentVersion returns the current version of the Contracts.

--- a/Generation/Go/template/VersionInfo.go
+++ b/Generation/Go/template/VersionInfo.go
@@ -7,9 +7,9 @@ import (
 // GetCurrentVersion returns the current version of the Contracts.
 func GetCurrentVersion() versioning.Version {
 	return versioning.Version{
-		Major:            100,
-		Minor:            200,
-		Patch:            300,
-		PreReleaseString: "LOCAL",
+		Major:            377,
+		Minor:            389,
+		Patch:            368,
+		PreReleaseString: "PRERELEASE",
 	}
 }

--- a/Generation/JavaScript/Fundamentals/VersionInfo.d.ts
+++ b/Generation/JavaScript/Fundamentals/VersionInfo.d.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Version } from './Versioning/Version_pb';
+
+/**
+ * Provides information about the current version of the Contracts.
+ */
+export class VersionInfo {
+    /**
+     * Gets the current {@link Version} of the Contracts.
+     */
+    static getCurrentVersion(): Version;
+}

--- a/Generation/JavaScript/Fundamentals/VersionInfo.js
+++ b/Generation/JavaScript/Fundamentals/VersionInfo.js
@@ -11,10 +11,10 @@ VersionInfo.prototype.getCurrentVersion = function() {
 
 VersionInfo.getCurrentVersion = function() {
     return new Fundamentals_Versioning_Version_pb.Version()
-        .setMajor(100)
-        .setMinor(200)
-        .setPatch(300)
-        .setPrereleasestring("LOCAL");
+        .setMajor(377)
+        .setMinor(389)
+        .setPatch(368)
+        .setPrereleasestring('PRERELEASE');
 }
 
 exports.VersionInfo = VersionInfo;

--- a/Generation/JavaScript/Fundamentals/VersionInfo.js
+++ b/Generation/JavaScript/Fundamentals/VersionInfo.js
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+var Fundamentals_Versioning_Version_pb = require('./Versioning/Version_pb');
+
+function VersionInfo() {}
+
+VersionInfo.prototype.getCurrentVersion = function() {
+    return VersionInfo.getCurrentVersion();
+}
+
+VersionInfo.getCurrentVersion = function() {
+    return new Fundamentals_Versioning_Version_pb.Version()
+        .setMajor(100)
+        .setMinor(200)
+        .setPatch(300)
+        .setPrereleasestring("LOCAL");
+}
+
+exports.VersionInfo = VersionInfo;

--- a/Generation/JavaScript/Runtime/VersionInfo.d.ts
+++ b/Generation/JavaScript/Runtime/VersionInfo.d.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Version } from '@dolittle/contracts/Versioning/Version_pb';
+
+/**
+ * Provides information about the current version of the Runtime Contracts.
+ */
+export class VersionInfo {
+    /**
+     * Gets the current {@link Version} of the Runtime Contracts.
+     */
+    static getCurrentVersion(): Version;
+}

--- a/Generation/JavaScript/Runtime/VersionInfo.js
+++ b/Generation/JavaScript/Runtime/VersionInfo.js
@@ -11,10 +11,10 @@ VersionInfo.prototype.getCurrentVersion = function() {
 
 VersionInfo.getCurrentVersion = function() {
     return new Fundamentals_Versioning_Version_pb.Version()
-        .setMajor(100)
-        .setMinor(200)
-        .setPatch(300)
-        .setPrereleasestring("LOCAL");
+        .setMajor(377)
+        .setMinor(389)
+        .setPatch(368)
+        .setPrereleasestring('PRERELEASE');
 }
 
 exports.VersionInfo = VersionInfo;

--- a/Generation/JavaScript/Runtime/VersionInfo.js
+++ b/Generation/JavaScript/Runtime/VersionInfo.js
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+var Fundamentals_Versioning_Version_pb = require('@dolittle/contracts/Versioning/Version_pb');
+
+function VersionInfo() {}
+
+VersionInfo.prototype.getCurrentVersion = function() {
+    return VersionInfo.getCurrentVersion();
+}
+
+VersionInfo.getCurrentVersion = function() {
+    return new Fundamentals_Versioning_Version_pb.Version()
+        .setMajor(100)
+        .setMinor(200)
+        .setPatch(300)
+        .setPrereleasestring("LOCAL");
+}
+
+exports.VersionInfo = VersionInfo;

--- a/Source/Runtime/Handshake/Handshake.proto
+++ b/Source/Runtime/Handshake/Handshake.proto
@@ -21,7 +21,7 @@ message HandshakeRequest {
     versioning.Version contractsVersion = 4;
 
     uint32 attempt = 5;
-    google.protobuf.Duration timeSpent = 3;
+    google.protobuf.Duration timeSpent = 6;
 }
 
 message HandshakeResponse {

--- a/Source/Runtime/Handshake/Handshake.proto
+++ b/Source/Runtime/Handshake/Handshake.proto
@@ -13,13 +13,19 @@ option csharp_namespace = "Dolittle.Runtime.Handshake.Contracts";
 option go_package = "go.dolittle.io/contracts/runtime/handshake";
 
 message HandshakeRequest {
+    string sdk = 1; // Enum?
+    versioning.Version sdkVersion = 2;
+    versioning.Version contractsVersion = 3;
+    versioning.Version headVersion = 4;
+    
 }
 
 message HandshakeResponse {
     protobuf.Failure failure = 1; // not set if not failed
     protobuf.Uuid microserviceId = 2;
-    versioning.Version version = 3;
-    string environment = 4;
+    string environment = 3;
+    versioning.Version runtimeVersion = 4;
+    versioning.Version contractsVersion = 5;
 }
 
 service Handshake {

--- a/Source/Runtime/Handshake/Handshake.proto
+++ b/Source/Runtime/Handshake/Handshake.proto
@@ -1,0 +1,27 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+syntax = "proto3";
+
+import "Fundamentals/Protobuf/Failure.proto";
+import "Fundamentals/Protobuf/Uuid.proto";
+import "Fundamentals/Versioning/Version.proto";
+
+package dolittle.runtime.handshake;
+
+option csharp_namespace = "Dolittle.Runtime.Handshake.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/handshake";
+
+message HandshakeRequest {
+}
+
+message HandshakeResponse {
+    protobuf.Failure failure = 1; // not set if not failed
+    protobuf.Uuid microserviceId = 2;
+    versioning.Version version = 3;
+    string environment = 4;
+}
+
+service Handshake {
+    rpc Handshake(HandshakeRequest) returns(HandshakeResponse);
+}

--- a/Source/Runtime/Handshake/Handshake.proto
+++ b/Source/Runtime/Handshake/Handshake.proto
@@ -14,18 +14,25 @@ option go_package = "go.dolittle.io/contracts/runtime/handshake";
 
 message HandshakeRequest {
     string sdkIdentifier = 1;
-    versioning.Version sdkVersion = 2;
-    versioning.Version contractsVersion = 3;
-    versioning.Version headVersion = 4;
-    
+
+    versioning.Version headVersion = 2;
+    versioning.Version sdkVersion = 3;
+    versioning.Version contractsVersion = 4;
 }
 
 message HandshakeResponse {
     protobuf.Failure failure = 1; // not set if not failed
-    protobuf.Uuid microserviceId = 2;
-    string environment = 3;
-    versioning.Version runtimeVersion = 4;
-    versioning.Version contractsVersion = 5;
+
+    versioning.Version runtimeVersion = 2;
+    versioning.Version contractsVersion = 3;
+
+    protobuf.Uuid customerId = 4;
+    string customerName = 5;
+    protobuf.Uuid applicationId = 6;
+    string applicationName = 7;
+    protobuf.Uuid microserviceId = 8;
+    string microserviceName = 9;
+    string environmentName = 10;
 }
 
 service Handshake {

--- a/Source/Runtime/Handshake/Handshake.proto
+++ b/Source/Runtime/Handshake/Handshake.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 import "Fundamentals/Protobuf/Failure.proto";
 import "Fundamentals/Protobuf/Uuid.proto";
 import "Fundamentals/Versioning/Version.proto";
+import "google/protobuf/duration.proto";
 
 package dolittle.runtime.handshake;
 
@@ -18,6 +19,9 @@ message HandshakeRequest {
     versioning.Version headVersion = 2;
     versioning.Version sdkVersion = 3;
     versioning.Version contractsVersion = 4;
+
+    uint32 attempt = 5;
+    google.protobuf.Duration timeSpent = 3;
 }
 
 message HandshakeResponse {

--- a/Source/Runtime/Handshake/Handshake.proto
+++ b/Source/Runtime/Handshake/Handshake.proto
@@ -13,7 +13,7 @@ option csharp_namespace = "Dolittle.Runtime.Handshake.Contracts";
 option go_package = "go.dolittle.io/contracts/runtime/handshake";
 
 message HandshakeRequest {
-    string sdk = 1; // Enum?
+    string sdkIdentifier = 1;
     versioning.Version sdkVersion = 2;
     versioning.Version contractsVersion = 3;
     versioning.Version headVersion = 4;


### PR DESCRIPTION
## Summary

Adds support for the client (SDKs) and Runtime to communicate version info and booting configuration values between each other through an initial handshake. Also added VersionInfo that is baked into the compiled code while building on GitHub to use to determine which version of the contracts is used at runtime.

### Added

- VersionInfo is baked into the released libraries
- Handshake method with HandshakeRequest and HandshakeResponse
