### PR TITLE
Handshake metrics and more information

### DIFF
--- a/Source/Runtime/Handshake/Handshake.proto
+++ b/Source/Runtime/Handshake/Handshake.proto
@@ -21,7 +21,7 @@ message HandshakeRequest {
     versioning.Version contractsVersion = 4;
 
     uint32 attempt = 5;
-    google.protobuf.Duration timeSpent = 3;
+    google.protobuf.Duration timeSpent = 6;
 }
 
 message HandshakeResponse {

--- a/Source/Runtime/Handshake/Handshake.proto
+++ b/Source/Runtime/Handshake/Handshake.proto
@@ -14,18 +14,25 @@ option go_package = "go.dolittle.io/contracts/runtime/handshake";
 
 message HandshakeRequest {
     string sdkIdentifier = 1;
-    versioning.Version sdkVersion = 2;
-    versioning.Version contractsVersion = 3;
-    versioning.Version headVersion = 4;
-    
+
+    versioning.Version headVersion = 2;
+    versioning.Version sdkVersion = 3;
+    versioning.Version contractsVersion = 4;
 }
 
 message HandshakeResponse {
     protobuf.Failure failure = 1; // not set if not failed
-    protobuf.Uuid microserviceId = 2;
-    string environment = 3;
-    versioning.Version runtimeVersion = 4;
-    versioning.Version contractsVersion = 5;
+
+    versioning.Version runtimeVersion = 2;
+    versioning.Version contractsVersion = 3;
+
+    protobuf.Uuid customerId = 4;
+    string customerName = 5;
+    protobuf.Uuid applicationId = 6;
+    string applicationName = 7;
+    protobuf.Uuid microserviceId = 8;
+    string microserviceName = 9;
+    string environmentName = 10;
 }
 
 service Handshake {

--- a/Source/Runtime/Handshake/Handshake.proto
+++ b/Source/Runtime/Handshake/Handshake.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 import "Fundamentals/Protobuf/Failure.proto";
 import "Fundamentals/Protobuf/Uuid.proto";
 import "Fundamentals/Versioning/Version.proto";
+import "google/protobuf/duration.proto";
 
 package dolittle.runtime.handshake;
 
@@ -18,6 +19,9 @@ message HandshakeRequest {
     versioning.Version headVersion = 2;
     versioning.Version sdkVersion = 3;
     versioning.Version contractsVersion = 4;
+
+    uint32 attempt = 5;
+    google.protobuf.Duration timeSpent = 3;
 }
 
 message HandshakeResponse {

--- a/Source/Runtime/Handshake/Handshake.proto
+++ b/Source/Runtime/Handshake/Handshake.proto
@@ -13,7 +13,7 @@ option csharp_namespace = "Dolittle.Runtime.Handshake.Contracts";
 option go_package = "go.dolittle.io/contracts/runtime/handshake";
 
 message HandshakeRequest {
-    string sdk = 1; // Enum?
+    string sdkIdentifier = 1;
     versioning.Version sdkVersion = 2;
     versioning.Version contractsVersion = 3;
     versioning.Version headVersion = 4;


### PR DESCRIPTION
## Summary

Adds a little more information to the handshake - and clients should now send over attempts and time spent doing handshake so we can use that for monitoring and metrics in the platform. Also got rid of the idea of using an enum for the `sdkIdentifier` - as that would require us to update contracts for every SDK we (or others) make, which isn't really a good idea. The `sdkIdentifier` is merely there for debugging purposes, kind of like the browser user-agent string.

### Added

- More information to the handshake response
- Handshake attempts and time to the request

### Changed

- Ordering of the handshake fields
- Name of the field `sdk` to `sdkIdentifier`