### PR TITLE
Gimli: SDK <-> Runtime Handshake and build time VersionInfo (FIXED)

### DIFF
--- a/Generation/CSharp/Fundamentals/VersionInfo.cs
+++ b/Generation/CSharp/Fundamentals/VersionInfo.cs
@@ -3,6 +3,8 @@
 
 using Dolittle.Versioning.Contracts;
 
+#pragma warning disable SA1122 // To allow replacing PreReleaseString with "" instead of string.Empty
+
 namespace Dolittle.Contracts
 {
     /// <summary>

--- a/Generation/CSharp/Runtime/VersionInfo.cs
+++ b/Generation/CSharp/Runtime/VersionInfo.cs
@@ -3,6 +3,8 @@
 
 using Dolittle.Versioning.Contracts;
 
+#pragma warning disable SA1122 // To allow replacing PreReleaseString with "" instead of string.Empty
+
 namespace Dolittle.Runtime.Contracts
 {
     /// <summary>


### PR DESCRIPTION
## Summary

Adds support for the client (SDKs) and Runtime to communicate version info and booting configuration values between each other through an initial handshake. Also added VersionInfo that is baked into the compiled code while building on GitHub to use to determine which version of the contracts is used at runtime.

Note: This PR is a fixed release of #76 that failed to release because pre-release is `""` when releasing the actual version.

### Added

- VersionInfo is baked into the released libraries
- Handshake method with HandshakeRequest and HandshakeResponse
