### PR TITLE
Add method on Projection Store to get all projections in batches.

### DIFF
--- a/Source/Runtime/Projections/Store.proto
+++ b/Source/Runtime/Projections/Store.proto
@@ -39,5 +39,6 @@ message GetAllResponse {
 // Represents the Projections service
 service Projections {
     rpc GetOne(GetOneRequest) returns(GetOneResponse);
-    rpc GetAll(GetAllRequest) returns(GetAllResponse);
+    rpc GetAll(GetAllRequest) returns(GetAllResponse); // DEPRECATED: This is superseeded by GetAllInBatches
+    rpc GetAllInBatches(GetAllRequest) returns(stream GetAllResponse);
 }


### PR DESCRIPTION
## Summary

Adds a method on Projection Store to get all projection read models in batches (size determined by Runtime), to alleviate large gRPC messages when the number of read models become large.

### Added

- A server streaming method on Projection Store called `GetAllInBatches` that streams projection states in batches to the client.

### Deprecated

- The `GetAll` method on Projection Store has been deprecated in favour of the new `GetAllInBatches` method.
