### PR TITLE
Add renamings, and change bson types to Date + Guid

### DIFF
--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -40,11 +40,11 @@ message ProjectionEventSelector {
 message ProjectionCopyToMongoDB {
     string collection = 1;
     map<string, BSONType> conversions = 2;
+    map<string, string> renamings = 3;
 
     enum BSONType {
         DATE = 0;
-        TIMESTAMP = 1;
-        BINARY = 2;
+        GUID = 1;
     }
 }
 


### PR DESCRIPTION
## Summary

Add specifications to rename projection fields, and support Date + Guid conversion types for now.