### PR TITLE
Merry: Management of Projections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Contracts CI/CD
 
 env:
-  PRERELEASE_BRANCHES: sam # Comma separated list of prerelease branch names. 'alpha,rc, ...'
+  PRERELEASE_BRANCHES: pippin, merry
 
 on:
   push:

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -75,6 +75,7 @@ message ProjectionRegistrationRequest {
     repeated ProjectionEventSelector events = 4;
     string initialState = 5;
     ProjectionCopies copies = 6;
+    optional string alias = 7;
 }
 
 message ProjectionReplaceResponse {

--- a/Source/Runtime/Management/Events.Processing/Projections.proto
+++ b/Source/Runtime/Management/Events.Processing/Projections.proto
@@ -1,0 +1,63 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+syntax = "proto3";
+
+import "Fundamentals/Protobuf/Uuid.proto";
+import "Fundamentals/Protobuf/Failure.proto";
+import "Runtime/Events.Processing/Projections.proto";
+import "Runtime/Management/Events.Processing/StreamProcessors.proto";
+
+package dolittle.runtime.events.processing.management;
+
+option csharp_namespace = "Dolittle.Runtime.Events.Processing.Management.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events/processing/management";
+
+message ReplayProjectionRequest {
+    // TODO: Do we want another kind of execution context here?
+    protobuf.Uuid scopeId = 1;
+    protobuf.Uuid projectionId = 2;
+    optional protobuf.Uuid tenantId = 3;
+}
+
+message ReplayProjectionResponse {
+    protobuf.Failure failure = 1; // not set if not failed
+}
+
+message GetAllProjectionsRequest {
+    // TODO: Do we want another kind of execution context here?
+    optional protobuf.Uuid tenantId = 1;
+}
+
+message ProjectionStatus {
+    protobuf.Uuid scopeId = 1;
+    protobuf.Uuid projectionId = 2;
+    repeated ProjectionEventSelector events = 4;
+    string initialState = 5;
+    ProjectionCopies copies = 6;
+    string alias = 7;
+    repeated TenantScopedStreamProcessorStatus tenants = 8;
+}
+
+message GetAllProjectionsResponse {
+    protobuf.Failure failure = 1; // not set if not failed
+    repeated ProjectionStatus projections = 2;
+}
+
+message GetOneProjectionRequest {
+    // TODO: Do we want another kind of execution context here?
+    protobuf.Uuid scopeId = 1;
+    protobuf.Uuid projectionId = 2;
+    optional protobuf.Uuid tenantId = 3;
+}
+
+message GetOneProjectionResponse {
+    protobuf.Failure failure = 1; // not set if not failed
+    ProjectionStatus projection = 2;
+}
+
+service Projections {
+    rpc Replay(ReplayProjectionRequest) returns(ReplayProjectionResponse);
+    rpc GetAll(GetAllProjectionsRequest) returns(GetAllProjectionsResponse);
+    rpc GetOne(GetOneProjectionRequest) returns(GetOneProjectionResponse);
+}


### PR DESCRIPTION
## Summary

Adds management service for projections, to list, get and replay registered projections. The get and list endpoints are mostly the same as for event handlers, but the replay endpoint only allows replaying from position 0 - since we don't keep track of intermediate projection states. An optional alias is also introduced on the projection registration request, to simplify human interaction with the Runtime.

### Added

- A Projections mangament service with GetAll, GetOne and Replay methods
- An optional alias on the projection registration request