### PR TITLE
Change prerelease name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Contracts CI/CD
 
 env:
-  PRERELEASE_BRANCHES: meriadoc
+  PRERELEASE_BRANCHES: mithrandir
 
 on:
   push:

--- a/Generation/CSharp/Contracts.csproj
+++ b/Generation/CSharp/Contracts.csproj
@@ -19,6 +19,13 @@
     <ItemGroup>
         <Protobuf Include="../../Source/**/*.proto" ProtoRoot="../../Source" OutputDir="%(RecursiveDir)" GrpcServices="Both" />
     </ItemGroup>
+    
+    <ItemGroup>
+        <Content Include="../../Source/**/*.proto">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <PackagePath>protos</PackagePath>
+        </Content>
+    </ItemGroup>
 
     <Target Name="DeleteSourceFiles" BeforeTargets="BeforeBuild">
         <ItemGroup>


### PR DESCRIPTION
## Summary

Copies all proto source files to a folder.

### Added

- The .proto source files will now be copied to a folder called `protos`
