### PR TITLE
Setup prerelease for streaming aggregate events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Contracts CI/CD
 
 env:
-  PRERELEASE_BRANCHES: mithrandir
+  PRERELEASE_BRANCHES: treebeard
 
 on:
   push:

--- a/Source/Runtime/Aggregates/AggregateRoots.proto
+++ b/Source/Runtime/Aggregates/AggregateRoots.proto
@@ -35,5 +35,5 @@ message AggregateRootVersionResponse {
 
 service AggregateRoots {
     rpc RegisterAlias(AggregateRootAliasRegistrationRequest) returns(AggregateRootAliasRegistrationResponse);
-    rpc GetVersion(AggregateRootVersionRequest) returns(AggregateRootVersionResponse)
+    rpc GetVersion(AggregateRootVersionRequest) returns(AggregateRootVersionResponse);
 }

--- a/Source/Runtime/Aggregates/AggregateRoots.proto
+++ b/Source/Runtime/Aggregates/AggregateRoots.proto
@@ -22,18 +22,6 @@ message AggregateRootAliasRegistrationResponse {
     protobuf.Failure failure = 1;
 }
 
-message AggregateRootVersionRequest {
-    services.CallRequestContext callContext = 1;
-    artifacts.Artifact aggregateRoot = 2;
-    string eventSourceId = 3;
-}
-
-message AggregateRootVersionResponse {
-    protobuf.Failure failure = 1;
-    uint64 aggregateRootVersion = 2;
-}
-
 service AggregateRoots {
     rpc RegisterAlias(AggregateRootAliasRegistrationRequest) returns(AggregateRootAliasRegistrationResponse);
-    rpc GetVersion(AggregateRootVersionRequest) returns(AggregateRootVersionResponse);
 }

--- a/Source/Runtime/Aggregates/AggregateRoots.proto
+++ b/Source/Runtime/Aggregates/AggregateRoots.proto
@@ -28,12 +28,12 @@ message AggregateRootVersionRequest {
     string eventSourceId = 3;
 }
 
-message AggregateRootAliasRegistrationResponse {
+message AggregateRootVersionResponse {
     protobuf.Failure failure = 1;
     uint64 aggregateRootVersion = 2;
 }
 
 service AggregateRoots {
     rpc RegisterAlias(AggregateRootAliasRegistrationRequest) returns(AggregateRootAliasRegistrationResponse);
-    rpc GetVersion() returns ()
+    rpc GetVersion(AggregateRootVersionRequest) returns(AggregateRootVersionResponse)
 }

--- a/Source/Runtime/Aggregates/AggregateRoots.proto
+++ b/Source/Runtime/Aggregates/AggregateRoots.proto
@@ -22,6 +22,18 @@ message AggregateRootAliasRegistrationResponse {
     protobuf.Failure failure = 1;
 }
 
+message AggregateRootVersionRequest {
+    services.CallRequestContext callContext = 1;
+    artifacts.Artifact aggregateRoot = 2;
+    string eventSourceId = 3;
+}
+
+message AggregateRootAliasRegistrationResponse {
+    protobuf.Failure failure = 1;
+    uint64 aggregateRootVersion = 2;
+}
+
 service AggregateRoots {
     rpc RegisterAlias(AggregateRootAliasRegistrationRequest) returns(AggregateRootAliasRegistrationResponse);
+    rpc GetVersion() returns ()
 }

--- a/Source/Runtime/Events/Committed.proto
+++ b/Source/Runtime/Events/Committed.proto
@@ -34,6 +34,7 @@ message CommittedAggregateEvents {
         artifacts.Artifact eventType = 4;
         bool public = 5;
         string content = 6;
+        uint64 aggregateRootVersion = 7; // The aggregate root version the event was applied to
     }
     string eventSourceId = 1;
     protobuf.Uuid aggregateRootId = 2;

--- a/Source/Runtime/Events/Committed.proto
+++ b/Source/Runtime/Events/Committed.proto
@@ -37,6 +37,7 @@ message CommittedAggregateEvents {
     }
     string eventSourceId = 1;
     protobuf.Uuid aggregateRootId = 2;
-    uint64 aggregateRootVersion = 3;
+    uint64 aggregateRootVersion = 3; [deprecated = true] // Replaced by currentAggregateRootVersion
     repeated CommittedAggregateEvent events = 4;
+    uint64 currentAggregateRootVersion = 5; // Represents the current version of the aggregate root
 }

--- a/Source/Runtime/Events/Committed.proto
+++ b/Source/Runtime/Events/Committed.proto
@@ -37,7 +37,7 @@ message CommittedAggregateEvents {
     }
     string eventSourceId = 1;
     protobuf.Uuid aggregateRootId = 2;
-    uint64 aggregateRootVersion = 3; [deprecated = true] // Replaced by currentAggregateRootVersion
+    uint64 aggregateRootVersion = 3 [deprecated = true]; // DEPRECATED Replaced by currentAggregateRootVersion
     repeated CommittedAggregateEvent events = 4;
     uint64 currentAggregateRootVersion = 5; // Represents the current version of the aggregate root
 }

--- a/Source/Runtime/Events/EventStore.proto
+++ b/Source/Runtime/Events/EventStore.proto
@@ -32,17 +32,16 @@ message FetchForAggregateRequest {
 message FetchForAggregateInBatchesRequest {
     services.CallRequestContext callContext = 1;
     Aggregate aggregate = 2;
-    oneof Request{
+    oneof Request {
         FetchAllEventsForAggregateInBatchesRequest fetchAllEvents = 3;
         FetchEventsForAggregateInBatchesRequest fetchEvents = 4;
-
     }
 }
 message FetchAllEventsForAggregateInBatchesRequest {
 }
 
-message FetchEventsForAggregateInBatchesRequest {@
-    repeated artifacts.Artifact eventTypes = 3;
+message FetchEventsForAggregateInBatchesRequest {
+    repeated artifacts.Artifact eventTypes = 1;
 }
 
 message CommitEventsResponse {

--- a/Source/Runtime/Events/EventStore.proto
+++ b/Source/Runtime/Events/EventStore.proto
@@ -3,6 +3,7 @@
 
 syntax = "proto3";
 
+import "Artifacts/Artifact.proto";
 import "Protobuf/Failure.proto";
 import "Services/CallContext.proto";
 import "Runtime/Events/Aggregate.proto";
@@ -28,6 +29,11 @@ message FetchForAggregateRequest {
     services.CallRequestContext callContext = 1;
     Aggregate aggregate = 2;
 }
+message FetchForAggregateInBatchesRequest {
+    services.CallRequestContext callContext = 1;
+    Aggregate aggregate = 2;
+    repeated artifacts.Artifact eventTypes = 3;
+}
 
 message CommitEventsResponse {
     protobuf.Failure failure = 1; // not set if not failed
@@ -48,5 +54,6 @@ message FetchForAggregateResponse {
 service EventStore {
     rpc Commit(CommitEventsRequest) returns(CommitEventsResponse);
     rpc CommitForAggregate(CommitAggregateEventsRequest) returns(CommitAggregateEventsResponse);
-    rpc FetchForAggregate(FetchForAggregateRequest) returns(FetchForAggregateResponse);
+    rpc FetchForAggregate(FetchForAggregateRequest) returns(FetchForAggregateResponse); // DEPRECATED: This is superseeded by FetchForAggregateInBatches
+    rpc FetchForAggregateInBatches(FetchForAggregateInBatchesRequest) returns (stream FetchForAggregateResponse);
 }

--- a/Source/Runtime/Events/EventStore.proto
+++ b/Source/Runtime/Events/EventStore.proto
@@ -32,6 +32,16 @@ message FetchForAggregateRequest {
 message FetchForAggregateInBatchesRequest {
     services.CallRequestContext callContext = 1;
     Aggregate aggregate = 2;
+    oneof Request{
+        FetchAllEventsForAggregateInBatchesRequest fetchAllEvents = 3;
+        FetchEventsForAggregateInBatchesRequest fetchEvents = 4;
+
+    }
+}
+message FetchAllEventsForAggregateInBatchesRequest {
+}
+
+message FetchEventsForAggregateInBatchesRequest {@
     repeated artifacts.Artifact eventTypes = 3;
 }
 


### PR DESCRIPTION
## Summary

Adds functionality that enables streaming of `FetchForAggregateResponse` and filtering of aggregate events based on event type. This is to be able to write an aggregate root rehydration implementation in the SDKs that only fetches the events that are relevant for rehydration and also fixes the problem that fetch for aggregate responses could be too large.

### Added

- `aggregateRootVersion` (field 7) on the inner `CommittedAggregateEvent` message in the `CommittedAggregateEvents` message. It represents the aggregate root version that the event was applied to
- `FetchForAggregateInBatches` method to `EventStore` which takes in a `FetchForAggregateInBatchesRequest` and streams back `FetchForAggregateResponse`

### Deprecated

- `aggregateRootVersion` (field 3) on `CommittedAggregateEvents` it represents the aggregate root version of the last event in the `events` sequence, it is now replaced by `currentAggregateRootVersion` (field 5)  which represents the current aggregate root version of the aggregate regardless of how many events are included in the sequence
