### PR TITLE
Deprecate old aggreagetRootVersion

### DIFF
--- a/Source/Runtime/Events/Committed.proto
+++ b/Source/Runtime/Events/Committed.proto
@@ -37,6 +37,7 @@ message CommittedAggregateEvents {
     }
     string eventSourceId = 1;
     protobuf.Uuid aggregateRootId = 2;
-    uint64 aggregateRootVersion = 3;
+    uint64 aggregateRootVersion = 3; [deprecated = true] // Replaced by currentAggregateRootVersion
     repeated CommittedAggregateEvent events = 4;
+    uint64 currentAggregateRootVersion = 5; // Represents the current version of the aggregate root
 }

--- a/Source/Runtime/Events/Committed.proto
+++ b/Source/Runtime/Events/Committed.proto
@@ -37,7 +37,7 @@ message CommittedAggregateEvents {
     }
     string eventSourceId = 1;
     protobuf.Uuid aggregateRootId = 2;
-    uint64 aggregateRootVersion = 3; [deprecated = true] // Replaced by currentAggregateRootVersion
+    uint64 aggregateRootVersion = 3 [deprecated = true]; // DEPRECATED Replaced by currentAggregateRootVersion
     repeated CommittedAggregateEvent events = 4;
     uint64 currentAggregateRootVersion = 5; // Represents the current version of the aggregate root
 }


### PR DESCRIPTION
## Summary

Deprecate old aggregateRootVersion field and add a new one representing the current aggregate root version of the aggregate regardless of the amount of aggregate events in the message 