### PR TITLE
Generate grpc-web package for Management services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,29 @@ jobs:
         working-directory: ./Generation/JavaScript
         run: yarn build
 
+  java-script-web-build:
+    name: JavaScript.Web Build
+    runs-on: ubuntu-latest
+    needs: context
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies
+        working-directory: ./Generation/JavaScript.Web
+        run: yarn
+      - name: Update VersionInfo
+        uses: dolittle/update-version-info-action@v1
+        with:
+          version: ${{ needs.context.outputs.versioninfo-version }}
+          files-to-update: |
+            Generation/JavaScript.Web/VersionInfo.js
+      - name: Build Contracts
+        working-directory: ./Generation.Web/JavaScript
+        run: yarn build
+
   golang-build:
     name: Go Build
     runs-on: ubuntu-latest
@@ -182,6 +205,46 @@ jobs:
           regex: '^\d+\.\d+.\d+-([^.]+)\.\d+$'
       - name: Publish Contracts
         working-directory: ./Generation/JavaScript
+        run: npm publish --tag ${{ needs.context.outputs.release-type == 'prerelease' && steps.tag_regex.outputs.group1 || 'latest' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+
+
+  java-script-web-release:
+    name: JavaScript.Web Release
+    runs-on: ubuntu-latest
+    needs: [context, release]
+    if: ${{ needs.context.outputs.should-publish == 'true' }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies
+        working-directory: ./Generation/JavaScript.Web
+        run: yarn
+      - name: Update VersionInfo
+        uses: dolittle/update-version-info-action@v1
+        with:
+          version: ${{ needs.context.outputs.versioninfo-version }}
+          files-to-update: |
+            Generation/JavaScript.Web/VersionInfo.js
+      - name: Build Contracts
+        working-directory: ./Generation/JavaScript.Web
+        run: yarn build
+      - name: Update Contracts version
+        working-directory: ./Generation/JavaScript.Web
+        run: npm version ${{ needs.context.outputs.version }}
+      - name: Extract tag from version
+        uses: actions-ecosystem/action-regex-match@v2
+        id: tag_regex
+        with:
+          text: ${{ needs.context.outputs.version }}
+          regex: '^\d+\.\d+.\d+-([^.]+)\.\d+$'
+      - name: Publish Contracts
+        working-directory: ./Generation/JavaScript.Web
         run: npm publish --tag ${{ needs.context.outputs.release-type == 'prerelease' && steps.tag_regex.outputs.group1 || 'latest' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           files-to-update: |
             Generation/JavaScript.Web/VersionInfo.js
       - name: Build Contracts
-        working-directory: ./Generation.Web/JavaScript
+        working-directory: ./Generation/JavaScript.Web
         run: yarn build
 
   golang-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [context, dot-net-build, java-script-build, golang-build]
+    needs: [context, dot-net-build, java-script-build, java-script-web-build, golang-build]
     if: ${{ needs.context.outputs.should-publish == 'true' }}
     steps:
       - uses: actions/checkout@v2
@@ -208,8 +208,6 @@ jobs:
         run: npm publish --tag ${{ needs.context.outputs.release-type == 'prerelease' && steps.tag_regex.outputs.group1 || 'latest' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-
 
   java-script-web-release:
     name: JavaScript.Web Release

--- a/.gitignore
+++ b/.gitignore
@@ -365,6 +365,13 @@ Generation/JavaScript/**/*.d.ts
 !Generation/JavaScript/VersionInfo.d.ts
 !Generation/JavaScript/VersionInfo.js
 
+# JavaScript.Web
+Generation/JavaScript.Web/**/*.js
+Generation/JavaScript.Web/**/*.d.ts
+!Generation/JavaScript.Web/package.json
+!Generation/JavaScript.Web/VersionInfo.d.ts
+!Generation/JavaScript.Web/VersionInfo.js
+
 # Go
 Generation/Go/*
 !Generation/Go/generate.sh

--- a/Generation/JavaScript.Web/VersionInfo.d.ts
+++ b/Generation/JavaScript.Web/VersionInfo.d.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { Version } from './Versioning/Version_pb';
+
+/**
+ * Provides information about the current version of the Contracts.
+ */
+export class VersionInfo {
+    /**
+     * Gets the current {@link Version} of the Contracts.
+     */
+    static getCurrentVersion(): Version;
+}

--- a/Generation/JavaScript.Web/VersionInfo.js
+++ b/Generation/JavaScript.Web/VersionInfo.js
@@ -1,0 +1,20 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+var Fundamentals_Versioning_Version_pb = require('./Versioning/Version_pb');
+
+function VersionInfo() {}
+
+VersionInfo.prototype.getCurrentVersion = function() {
+    return VersionInfo.getCurrentVersion();
+}
+
+VersionInfo.getCurrentVersion = function() {
+    return new Fundamentals_Versioning_Version_pb.Version()
+        .setMajor(377)
+        .setMinor(389)
+        .setPatch(368)
+        .setPrereleasestring('PRERELEASE');
+}
+
+exports.VersionInfo = VersionInfo;

--- a/Generation/JavaScript.Web/package.json
+++ b/Generation/JavaScript.Web/package.json
@@ -1,0 +1,38 @@
+{
+    "name": "@dolittle/contracts.web",
+    "description": "Grpc-Web contracts for Dolittle Fundamentals",
+    "version": "0.0.0",
+    "homepage": "https://dolittle.io",
+    "author": "Dolittle",
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/dolittle-runtime/contracts.git"
+    },
+    "bugs": {
+        "url": "https://github.com/dolittle/home/issues"
+    },
+    "keywords": [
+        "dolittle",
+        "grpc"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "protofiles": "find ../../Source -name '*.proto'",
+        "generate": "grpc_tools_node_protoc --js_out=import_style=commonjs:. --grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:. --plugin=protoc-gen-grpc=`which grpc_tools_node_protoc_plugin` -I../../Source $(yarn -s protofiles)",
+        "keep_only_management_services": "find . -name '*_grpc_web_pb.*' -and -not -path './Runtime/Management/*' -delete",
+        "build": "yarn generate && yarn keep_only_management_services",
+        "prepublish": "yarn build"
+    },
+    "dependencies": {
+        "@types/google-protobuf": "3.15.5",
+        "grpc-web": "1.4.1",
+        "google-protobuf": "3.19.4"
+    },
+    "devDependencies": {
+        "grpc-tools": "1.11.2",
+        "protoc-gen-grpc-web": "1.4.0"
+    }
+}


### PR DESCRIPTION
Added first test of grpc-web code generation for Contracts. It generates Protobuf code for all the types, but only generates gRPC (web) code for the services in `Runtime/Management` - it doesn't really make sense to expose the other ones now.